### PR TITLE
feat(rewind): session-native rewind store with lineage and retention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,28 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-## [1.7.3] - 2026-01-26
+### Changed
+- Replaced the old git-ref checkpoint ledger with session-native `rewind-turn` and `rewind-op` records
+- Rewind points are now aligned to visible session nodes: the triggering user node and each assistant step captured at `turn_end`
+- Snapshot commits are now kept reachable through a single `refs/pi-rewind/store` keepalive ref instead of one ref per checkpoint
+- Removed the fixed 100-checkpoint per-session pruning model; exact mode now has no cap by default
+- `/fork` and `/tree` now persist resulting exact file state through `rewind-op.current`, including keep-current-files flows
+- Undo snapshots now persist with the resulting session state instead of depending on old before-restore refs
+
+### Added
+- Lineage-aware exact snapshot lookup through `parentSession`
+- Exact assistant-node rewind for v2 captures
+- Compaction and branch-summary snapshot aliasing without creating fresh snapshots when files did not change
+- Optional retention over unique snapshot commits via `rewind.retention.maxSnapshots`, `rewind.retention.maxAgeDays`, and `rewind.retention.pinLabeledEntries`
+- Retention discovery mode setting via `rewind.retention.scanMode` (`ancestor-only` default, optional `repo-sessions`)
+- Startup retention sweep budget setting via `rewind.retention.startupBudgetMs`
 
 ### Fixed
-- Install script now uses auto-discovery instead of adding to `settings.extensions`
-- Install script now downloads `package.json` with `pi.extensions` declaration
-- Removes rewind from explicit extensions array if present (prevents duplicate loading errors)
-
-## [1.7.2] - 2026-01-26
-
-### Changed
-- Added `pi-package` keyword for npm discoverability (pi v0.50.0 package system)
-
-## [1.7.1] - 2026-01-22
-
-### Changed
-- Reordered restore menus to show non-file-restorative options first (most common action)
-  - Branch menu: "Conversation only" now appears first
-  - Tree navigation: "Keep current files" now appears first
-
-### Fixed
-- Resume checkpoint now session-scoped (`checkpoint-resume-{sessionId}-{timestamp}`) for consistency with other checkpoint types
+- Restore now deletes files absent from the target snapshot before worktree-only restore, producing exact restore for tracked and untracked non-ignored files in the snapshot domain without staging the repo index
+- Rewind bookkeeping for reconstruction, capture, migration, and retention no longer depends on UI availability
+- `/tree` restore options now match actual exact rewind availability: user, assistant, compaction, and branch-summary nodes only
+- Critical rewind handlers now fail closed with user-facing errors instead of bubbling git/storage exceptions through `/fork` and `/tree`
+- Turn capture/finalization now warns and recovers when snapshot writes fail, avoiding stale collector state
 
 ## [1.7.0] - 2026-01-15
 
@@ -46,12 +47,12 @@ All notable changes to this project will be documented in this file.
 - Old-format checkpoints are not pruned (to avoid cross-session interference)
 - New checkpoints are created in the new session-scoped format
 
-## [1.6.0] - 2025-01-13
+## [1.6.0] - 2026-01-13
 
 ### Added
 - `rewind.silentCheckpoints` setting to hide checkpoint status and notifications
 
-## [1.5.0] - 2025-01-10
+## [1.5.0] - 2026-01-10
 
 ### Changed
 - Replaced noisy stderr logging with clean TUI output
@@ -97,7 +98,7 @@ All notable changes to this project will be documented in this file.
 - Install script now migrates old hooks config and cleans up old directory
 - Renamed "Hook" to "Extension" throughout codebase and docs
 
-## [1.2.0] - 2025-01-03
+## [1.2.0] - 2026-01-03
 
 ### Added
 - Tree navigation support (`session_before_tree`) - restore files when navigating session tree
@@ -111,13 +112,13 @@ All notable changes to this project will be documented in this file.
 - Removed `agent_end` handler that was clearing checkpoints after each turn
 - "Undo last file rewind" now cancels branch instead of creating unwanted branch
 
-## [1.1.1] - 2024-12-27
+## [1.1.1] - 2025-12-27
 
 ### Fixed
 - Use `before_branch` event instead of `branch` for proper hook timing (thanks @badlogic)
 - Cancel branch when user dismisses restore options menu
 
-## [1.1.0] - 2024-12-27
+## [1.1.0] - 2025-12-27
 
 ### Added
 - "Undo last file rewind" option - restore files to state before last rewind
@@ -131,7 +132,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Code-only restore options now properly skip conversation restore
 
-## [1.0.0] - 2024-12-19
+## [1.0.0] - 2025-12-19
 
 ### Added
 - Initial release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.8.0] - 2026-04-03
+
 ### Changed
 - Replaced the old git-ref checkpoint ledger with session-native `rewind-turn` and `rewind-op` records
 - Rewind points are now aligned to visible session nodes: the triggering user node and each assistant step captured at `turn_end`

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-![pi-rewind](banner.png)
-
 # Rewind Extension
 
-A Pi agent extension that enables rewinding file changes during coding sessions. Creates automatic checkpoints using git refs, allowing you to restore files to previous states while optionally preserving conversation history.
+A Pi agent extension that records exact file-state rewind points, allowing restoration of file states during `/tree` navigation and across resumed and forked sessions
+
+Rewind metadata lives in the session itself as hidden entries, so rewind history survives across forks, resumes, tree navigation, and compaction. Snapshot commits are kept reachable through a single git ref rather than one ref per checkpoint, and rewind points can be resolved across session lineage via `parentSession` links. Retention is optional and configurable; without it, exact history is kept indefinitely.
 
 ## Screenshots
 
@@ -12,129 +12,93 @@ A Pi agent extension that enables rewinding file changes during coding sessions.
 
 ## Requirements
 
-- Pi agent v0.35.0+ (unified extensions system)
+- Pi agent v0.35.0+
 - Node.js (for installation)
-- Git repository (checkpoints are stored as git refs)
+- Git repository
 
 ## Installation
 
 ```bash
-pi install npm:pi-rewind-hook
+npx pi-rewind-hook
 ```
 
 This will:
 1. Create `~/.pi/agent/extensions/rewind/`
 2. Download the extension files
 3. Add the extension to your `~/.pi/agent/settings.json`
-4. Migrate any existing hooks config to extensions (if upgrading from v1.2.0)
+4. Migrate any existing hooks config to extensions (if upgrading from an older version)
 5. Clean up old `hooks/rewind` directory (if present)
 
-### Alternative Installation
-
-Using curl:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/nicobailon/pi-rewind-hook/main/install.js | node
-```
-
-Or clone the repo and configure manually:
-
-```bash
-git clone https://github.com/nicobailon/pi-rewind-hook ~/.pi/agent/extensions/rewind
-```
-
-Then add to `~/.pi/agent/settings.json`:
-
-```json
-{
-  "extensions": ["~/.pi/agent/extensions/rewind/index.ts"]
-}
-```
-
-### Platform Notes
-
-**Windows:** The `npx` command works in PowerShell, Command Prompt, and WSL. If you prefer curl on Windows without WSL:
-
-```powershell
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/nicobailon/pi-rewind-hook/main/install.js" -OutFile install.js; node install.js; Remove-Item install.js
-```
-
-### Upgrading from v1.2.0
-
-If you're upgrading from pi-rewind-hook v1.2.0 (which used the hooks system), simply run `npx pi-rewind-hook` again. The installer will:
-- Move the extension from `hooks/rewind` to `extensions/rewind`
-- Migrate your settings.json from `hooks` to `extensions`
-- Clean up the old hooks directory
-
-**Note:** v1.3.0+ requires pi v0.35.0 or later. If you're on an older version of pi, stay on pi-rewind-hook v1.2.0.
+Or clone the repo into `~/.pi/agent/extensions/rewind/` — Pi discovers extensions in that directory automatically.
 
 ## Configuration
 
-You can configure the extension by adding settings to `~/.pi/agent/settings.json`:
+Optionally add settings to `~/.pi/agent/settings.json`.  For example:
 
 ```json
 {
-  "extensions": ["~/.pi/agent/extensions/rewind/index.ts"],
   "rewind": {
-    "silentCheckpoints": true
+    "silentCheckpoints": true,
+    "retention": {
+      "maxSnapshots": 2000,
+      "maxAgeDays": 30,
+      "pinLabeledEntries": true
+    }
   }
 }
 ```
 
 ### Settings
 
-- **`rewind.silentCheckpoints`** (boolean, default: `false`): When set to `true`, disables checkpoint status messages. The footer checkpoint count (`◆ X checkpoints`) and checkpoint saved notifications (`Checkpoint X saved`) will not be displayed.
+- `rewind.silentCheckpoints` — hides footer/status and checkpoint notifications
+- `rewind.retention.maxSnapshots` — optional cap on unpinned unique snapshot commits kept reachable
+- `rewind.retention.maxAgeDays` — optional age limit for unpinned snapshot commits
+- `rewind.retention.pinLabeledEntries` — when true, snapshot commits bound to **labeled nodes** in the Pi session tree are exempt from `maxSnapshots` and `maxAgeDays` pruning (useful for bookmarking important rewind points you want to prevent getting garbage-collected)
+- `rewind.retention.scanMode` — retention discovery mode: `ancestor-only` (default, follow current session lineage only) or `repo-sessions` (scan discovered session roots)
+- `rewind.retention.startupBudgetMs` — optional startup time budget for retention sweeps; if exceeded, startup sweep is skipped and deferred
 
-## How It Works
+If `rewind.retention` is omitted, Rewind keeps exact history with no automatic expiration. This can grow git object storage without bound over time.
 
-### Checkpoints
+## Usage
 
-The extension creates git refs at two points:
+### Rewinding via `/fork`
 
-1. **Session start** - When pi starts, creates a "resume checkpoint" of the current file state
-2. **Each turn** - Before the agent processes each message, creates a checkpoint
-
-Checkpoints are stored as git refs under `refs/pi-checkpoints/` and are scoped per-session (so multiple pi sessions in the same repo don't interfere with each other). Each session maintains its own 100-checkpoint limit.
-
-### Rewinding
-
-To rewind via `/fork`:
-
-1. Type `/fork` in pi
+1. Type `/fork` in Pi
 2. Select a message to branch from
 3. Choose a restore option
 
-To rewind via tree navigation:
+**Options:**
+
+| Option | Files | Conversation |
+|--------|-------|-------------|
+| **Conversation only (keep current files)** | Unchanged | Reset to that point |
+| **Restore all (files + conversation)** | Restored | Reset to that point |
+| **Code only (restore files, keep conversation)** | Restored | Unchanged |
+| **Undo last file rewind** | Restored to before last rewind | Unchanged |
+
+`Restore all`, `Code only`, and `Undo last file rewind` are only shown when an exact rewind point or undo snapshot is available for the selected message.
+
+When you restore files during `/fork`, the undo snapshot is persisted in the **new child session**, because that is where you continue working.
+
+### Rewinding via `/tree`
 
 1. Press `Tab` to open the session tree
 2. Navigate to a different node
 3. Choose a restore option
 
-**For messages from the current session:**
+**Options:**
 
 | Option | Files | Conversation |
-|--------|-------|--------------|
-| **Restore all (files + conversation)** | Restored | Reset to that point |
-| **Conversation only (keep current files)** | Unchanged | Reset to that point |
-| **Code only (restore files, keep conversation)** | Restored | Unchanged |
-| **Undo last file rewind** | Restored to before last rewind | Unchanged |
+|--------|-------|-------------|
+| **Keep current files** | Unchanged | Navigated to that point |
+| **Restore files to that point** | Restored | Navigated to that point |
+| **Undo last file rewind** | Restored to before last rewind | Navigated to that point |
 
-**For messages from before the current session (uses resume checkpoint):**
+If you navigate with `Keep current files`, Rewind still persists the resulting session position's exact current file baseline via `rewind-op.current`.
 
-| Option | Files | Conversation |
-|--------|-------|--------------|
-| **Restore to session start (files + conversation)** | Restored to session start | Reset to that point |
-| **Conversation only (keep current files)** | Unchanged | Reset to that point |
-| **Restore to session start (files only, keep conversation)** | Restored to session start | Unchanged |
-| **Undo last file rewind** | Restored to before last rewind | Unchanged |
+### Examples
 
-### Resumed Sessions
-
-When you resume a session (`pi --resume`), the extension creates a resume checkpoint. If you branch to a message from before the current session, you can restore files to the state when you resumed (not per-message granularity, but a safety net).
-
-## Examples
-
-### Undo a bad refactor
+**Undo a bad refactor:**
 
 ```
 You: refactor the auth module to use JWT
@@ -147,7 +111,7 @@ You: /fork
 Result: Files restored, conversation intact. Try a different approach.
 ```
 
-### Start fresh from a checkpoint
+**Start fresh from an earlier point:**
 
 ```
 You: /fork
@@ -157,42 +121,96 @@ You: /fork
 Result: Both files and conversation reset to that point.
 ```
 
-### Recover after resuming
+## How Rewind works
+
+Rewind stores its ledger in hidden session `custom` entries:
+
+- `rewind-turn` — one per prompt, containing the triggering user-node snapshot plus any assistant-node snapshots produced during that prompt
+- `rewind-op` — sparse records for `/fork`, `/tree`, compaction aliases, summary aliases, and undo state
+
+Snapshots are only considered at visible boundaries:
+
+- the user pre-prompt boundary
+- each assistant `turn_end`
+- selected stateful session operations
+
+Rewind does not create per-tool snapshots.
+
+### Canonical exact rewind points
+
+Exact file restore is available for:
+
+- user nodes
+- assistant nodes
+- compaction nodes aliased to the current exact state
+- branch-summary nodes aliased during `/tree`
+
+Exact file restore is not offered for toolResult nodes.
+
+### Git storage model
+
+Snapshot commits are kept reachable through a single repo-local ref:
+
+```text
+refs/pi-rewind/store
+```
+
+That ref is only for git object reachability; the session ledger is authoritative.
+
+### Deduplication
+
+Before creating a snapshot commit, Rewind captures the worktree tree SHA. If it matches the latest exact snapshot tree, Rewind reuses that existing snapshot commit instead of creating a new one.
+
+### Restore exactness and scope
+
+Rewind restores the exact file state for the snapshot domain it owns:
+
+- tracked files
+- untracked, non-ignored files
+- without staging the real git index during restore
+
+Before restoring target contents, it deletes paths present in the current snapshot but absent from the target snapshot, then restores the target snapshot into the worktree only.
+
+Out of scope:
+
+- ignored files
+- empty directories
+- exact rewind points for `toolResult` nodes
+- exact rewind points for `bashExecution` nodes
+
+## Lineage and resume behavior
+
+Rewind resolves exact rewind points across session lineage by following `parentSession` links and reading rewind metadata from ancestor session files.
+
+Rewind v2 uses only session-native `rewind-turn`/`rewind-op` metadata and does not read legacy checkpoint refs.
+
+## Retention
+
+Retention only affects git reachability. Session JSONL metadata is append-only and is never compacted by Rewind.
+
+When retention is enabled, Rewind keeps snapshot commits alive if they are referenced by:
+
+- a `rewind-turn` or `rewind-op` binding in a discovered same-repo session
+- the latest `rewind-op.current` for a discovered same-repo session
+- the latest `rewind-op.undo` for a discovered same-repo session
+- a labeled bound entry when `pinLabeledEntries` is enabled
+
+If a snapshot commit has been pruned, Rewind validates commit existence before offering restore.
+
+If retention discovery yields an empty live set, Rewind preserves the existing `refs/pi-rewind/store` ref rather than deleting it.
+
+## Viewing storage
+
+Show the store ref head:
 
 ```bash
-pi --resume  # resume old session
+git rev-parse refs/pi-rewind/store
 ```
 
-```
-Agent: [immediately breaks something]
-
-You: /fork
-→ Select any old message
-→ Select "Restore to session start (files only, keep conversation)"
-
-Result: Files restored to state when you resumed.
-```
-
-## Viewing Checkpoints
-
-List all checkpoint refs:
+Show the hidden rewind ledger in a session file:
 
 ```bash
-git for-each-ref refs/pi-checkpoints/
-```
-
-Checkpoint ref format: `checkpoint-{sessionId}-{timestamp}-{entryId}`
-
-Manually restore to a checkpoint (copy ref name from list above):
-
-```bash
-git checkout refs/pi-checkpoints/checkpoint-abc12345-...-... -- .
-```
-
-Delete all checkpoints:
-
-```bash
-git for-each-ref --format='%(refname)' refs/pi-checkpoints/ | xargs -n1 git update-ref -d
+grep '"customType":"rewind-' ~/.pi/agent/sessions/**/*.jsonl
 ```
 
 ## Uninstalling
@@ -201,19 +219,17 @@ git for-each-ref --format='%(refname)' refs/pi-checkpoints/ | xargs -n1 git upda
    ```bash
    rm -rf ~/.pi/agent/extensions/rewind
    ```
-   On Windows (PowerShell): `Remove-Item -Recurse -Force ~/.pi/agent/extensions/rewind`
 
-2. Remove the extension from `~/.pi/agent/settings.json` (delete the line with `rewind/index.ts` from the `extensions` array)
+2. Remove any `rewind` key from `~/.pi/agent/settings.json` if you added one
 
-3. Optionally, clean up git refs in each repo where you used the extension:
+3. Optionally, clean up the git reachability ref in each repo where you used the extension:
    ```bash
-   git for-each-ref --format='%(refname)' refs/pi-checkpoints/ | xargs -n1 git update-ref -d
+   git update-ref -d refs/pi-rewind/store
    ```
 
 ## Limitations
 
 - Only works in git repositories
-- Checkpoints are scoped per-session (multiple sessions in the same repo don't share checkpoints)
-- Resumed sessions only have a single resume checkpoint for pre-session messages
-- Tracks working directory changes only (not staged/committed changes)
-- Each session has its own 100-checkpoint limit (pruning doesn't affect other sessions)
+- Session metadata grows append-only; retention only trims git reachability
+- Discovery for retention is best-effort across discovered Pi session roots and explicit `parentSession` ancestors
+- Ignored files and empty directories are outside the snapshot model

--- a/index.test.ts
+++ b/index.test.ts
@@ -1,0 +1,602 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import test from "node:test";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import rewindExtension from "./index.ts";
+
+const execFileAsync = promisify(execFile);
+const STORE_REF = "refs/pi-rewind/store";
+
+type RewindEntry = Record<string, unknown>;
+type EventHandler = (event: any, ctx: any) => Promise<any> | any;
+
+class SessionManagerStub {
+  private readonly header: { type: "session"; version: number; id: string; timestamp: string; cwd: string; parentSession?: string };
+  private entries: RewindEntry[];
+  private readonly sessionFile: string;
+
+  constructor(options: {
+    sessionFile: string;
+    id: string;
+    cwd: string;
+    parentSession?: string;
+    entries?: RewindEntry[];
+  }) {
+    this.sessionFile = options.sessionFile;
+    this.header = {
+      type: "session",
+      version: 3,
+      id: options.id,
+      timestamp: new Date().toISOString(),
+      cwd: options.cwd,
+      parentSession: options.parentSession,
+    };
+    this.entries = options.entries ?? [];
+    this.flush();
+  }
+
+  flush(): void {
+    mkdirSync(path.dirname(this.sessionFile), { recursive: true });
+    const lines = [this.header, ...this.entries].map((entry) => JSON.stringify(entry)).join("\n") + "\n";
+    writeFileSync(this.sessionFile, lines);
+  }
+
+  replaceEntries(entries: RewindEntry[]): void {
+    this.entries = entries;
+    this.flush();
+  }
+
+  appendCustom(customType: string, data: unknown): void {
+    const parentId = (this.entries.at(-1)?.id as string | undefined) ?? null;
+    this.entries.push({
+      type: "custom",
+      customType,
+      data,
+      id: `${customType}-${this.entries.length + 1}`,
+      parentId,
+      timestamp: new Date().toISOString(),
+    });
+    this.flush();
+  }
+
+  getSessionId(): string {
+    return this.header.id;
+  }
+
+  getSessionFile(): string {
+    return this.sessionFile;
+  }
+
+  getHeader(): { parentSession?: string } {
+    return { parentSession: this.header.parentSession };
+  }
+
+  getCwd(): string {
+    return this.header.cwd;
+  }
+
+  getEntries(): RewindEntry[] {
+    return this.entries;
+  }
+
+  getBranch(): RewindEntry[] {
+    return this.entries;
+  }
+
+  getEntry(entryId: string): RewindEntry | undefined {
+    return this.entries.find((entry) => entry.id === entryId);
+  }
+}
+
+async function runGit(repoRoot: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  try {
+    const { stdout, stderr } = await execFileAsync("git", args, { cwd: repoRoot });
+    return { stdout, stderr, code: 0 };
+  } catch (error: any) {
+    return {
+      stdout: error.stdout ?? "",
+      stderr: error.stderr ?? error.message ?? "",
+      code: error.code ?? 1,
+    };
+  }
+}
+
+async function runGitChecked(repoRoot: string, args: string[]): Promise<{ stdout: string; stderr: string; code: number }> {
+  const result = await runGit(repoRoot, args);
+  if (result.code !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${result.stderr || `exit ${result.code}`}`);
+  }
+  return result;
+}
+
+async function gitStdout(repoRoot: string, args: string[]): Promise<string> {
+  return (await runGitChecked(repoRoot, args)).stdout.trim();
+}
+
+async function revParseOptional(repoRoot: string, ref: string): Promise<string | undefined> {
+  try {
+    return await gitStdout(repoRoot, ["rev-parse", ref]);
+  } catch {
+    return undefined;
+  }
+}
+
+async function isAncestor(repoRoot: string, ancestor: string, descendant: string): Promise<boolean> {
+  try {
+    await runGitChecked(repoRoot, ["merge-base", "--is-ancestor", ancestor, descendant]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function captureSnapshot(repoRoot: string): Promise<string> {
+  await runGitChecked(repoRoot, ["add", "-A"]);
+  const treeSha = await gitStdout(repoRoot, ["write-tree"]);
+  return await gitStdout(repoRoot, ["commit-tree", treeSha, "-m", "rewind snapshot test"]);
+}
+
+async function createHarness(options: {
+  settings?: Record<string, unknown>;
+  failGitSubcommands?: string[];
+} = {}) {
+  const root = await mkdtemp(path.join(os.tmpdir(), "rewind-ext-test-"));
+  const repoRoot = path.join(root, "repo");
+  const agentDir = path.join(root, "agent");
+  const sessionsDir = path.join(agentDir, "sessions", "--repo--");
+  mkdirSync(repoRoot, { recursive: true });
+  mkdirSync(sessionsDir, { recursive: true });
+  writeFileSync(path.join(agentDir, "settings.json"), JSON.stringify(options.settings ?? {}, null, 2) + "\n");
+
+  const originalAgentDir = process.env.PI_CODING_AGENT_DIR;
+  process.env.PI_CODING_AGENT_DIR = agentDir;
+
+  await runGitChecked(repoRoot, ["init"]);
+  await runGitChecked(repoRoot, ["config", "user.name", "Rewind Test"]);
+  await runGitChecked(repoRoot, ["config", "user.email", "rewind@example.com"]);
+
+  const handlers = new Map<string, EventHandler>();
+  const eventHandlers = new Map<string, (data: any) => void>();
+  const execCalls: string[][] = [];
+  const notifications: Array<{ message: string; level: string }> = [];
+  const statusUpdates: Array<{ key: string; value: string | undefined }> = [];
+  const selectCalls: Array<{ title: string; options: string[] }> = [];
+  const pendingSelections: string[] = [];
+
+  const currentSession = new SessionManagerStub({
+    sessionFile: path.join(sessionsDir, "session-1.jsonl"),
+    id: "session-1",
+    cwd: repoRoot,
+  });
+  let activeSession = currentSession;
+
+  const api = {
+    exec: async (cmd: string, args: string[]) => {
+      execCalls.push([cmd, ...args]);
+      if (cmd !== "git") {
+        throw new Error(`Unsupported command in test harness: ${cmd}`);
+      }
+
+      const gitSubcommand = args[0] ?? "";
+      if (options.failGitSubcommands?.includes(gitSubcommand)) {
+        return {
+          stdout: "",
+          stderr: `forced git failure for ${gitSubcommand}`,
+          code: 1,
+        };
+      }
+
+      return runGit(repoRoot, args);
+    },
+    appendEntry: (customType: string, data: unknown) => {
+      activeSession.appendCustom(customType, data);
+    },
+    on: (eventName: string, handler: EventHandler) => {
+      handlers.set(eventName, handler);
+    },
+    events: {
+      on: (eventName: string, handler: (data: any) => void) => {
+        eventHandlers.set(eventName, handler);
+      },
+    },
+  } as any;
+
+  rewindExtension(api);
+
+  function createContext(sessionManager: SessionManagerStub, hasUI = true): any {
+    return {
+      cwd: repoRoot,
+      hasUI,
+      sessionManager,
+      ui: {
+        notify: (message: string, level: string) => {
+          notifications.push({ message, level });
+        },
+        setStatus: (key: string, value: string | undefined) => {
+          statusUpdates.push({ key, value });
+        },
+        select: async (title: string, choices: string[]) => {
+          selectCalls.push({ title, options: choices });
+          return pendingSelections.shift();
+        },
+        theme: {
+          fg: (_color: string, text: string) => text,
+        },
+      },
+    };
+  }
+
+  return {
+    repoRoot,
+    agentDir,
+    currentSession,
+    execCalls,
+    notifications,
+    selectCalls,
+    statusUpdates,
+    enqueueSelection(choice: string) {
+      pendingSelections.push(choice);
+    },
+    async writeRepoFile(relativePath: string, content: string) {
+      const filePath = path.join(repoRoot, relativePath);
+      mkdirSync(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, content);
+    },
+    readRepoFile(relativePath: string) {
+      return readFileSync(path.join(repoRoot, relativePath), "utf-8");
+    },
+    createSession(options: { id: string; parentSession?: string; entries?: RewindEntry[] }) {
+      return new SessionManagerStub({
+        sessionFile: path.join(sessionsDir, `${options.id}.jsonl`),
+        id: options.id,
+        cwd: repoRoot,
+        parentSession: options.parentSession,
+        entries: options.entries,
+      });
+    },
+    async invoke(eventName: string, event: any, sessionManager = activeSession, hasUI = true) {
+      const handler = handlers.get(eventName);
+      assert.ok(handler, `missing handler for ${eventName}`);
+      activeSession = sessionManager;
+      return handler(event, createContext(sessionManager, hasUI));
+    },
+    async captureSnapshot() {
+      return captureSnapshot(repoRoot);
+    },
+    async revParseStore() {
+      return revParseOptional(repoRoot, STORE_REF);
+    },
+    async updateStoreRef(commitSha: string) {
+      await runGitChecked(repoRoot, ["update-ref", STORE_REF, commitSha]);
+    },
+    async isAncestor(ancestor: string, descendant: string) {
+      return isAncestor(repoRoot, ancestor, descendant);
+    },
+    eventHandlers,
+    async cleanup() {
+      if (originalAgentDir === undefined) {
+        delete process.env.PI_CODING_AGENT_DIR;
+      } else {
+        process.env.PI_CODING_AGENT_DIR = originalAgentDir;
+      }
+      await rm(root, { recursive: true, force: true });
+    },
+  };
+}
+
+test("/fork undo restores files into a child session instead of cancelling the fork", async () => {
+  const harness = await createHarness({ settings: { rewind: { silentCheckpoints: true } } });
+
+  try {
+    await harness.writeRepoFile("notes.txt", "current state\n");
+    const currentCommit = await harness.captureSnapshot();
+    await harness.writeRepoFile("notes.txt", "undo target\n");
+    const undoCommit = await harness.captureSnapshot();
+    await harness.writeRepoFile("notes.txt", "current state\n");
+
+    harness.currentSession.replaceEntries([
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: { role: "user", content: [{ type: "text", text: "Fork from here" }] },
+      },
+      {
+        type: "custom",
+        id: "rewind-op-1",
+        parentId: "user-1",
+        timestamp: new Date().toISOString(),
+        customType: "rewind-op",
+        data: { v: 2, snapshots: [currentCommit, undoCommit], current: 0, undo: 1 },
+      },
+    ]);
+
+    await harness.invoke("session_start", {});
+    harness.enqueueSelection("Undo last file rewind");
+
+    const result = await harness.invoke("session_before_fork", { entryId: "user-1" });
+    assert.equal(result, undefined);
+    assert.equal(harness.readRepoFile("notes.txt"), "undo target\n");
+
+    const currentSessionRewindOps = harness.currentSession.getEntries().filter((entry) => entry.type === "custom" && entry.customType === "rewind-op");
+    assert.equal(currentSessionRewindOps.length, 1);
+
+    const childSession = harness.createSession({
+      id: "session-2",
+      parentSession: harness.currentSession.getSessionFile(),
+    });
+    await harness.invoke("session_fork", {}, childSession);
+
+    const childRewindOps = childSession.getEntries().filter((entry) => entry.type === "custom" && entry.customType === "rewind-op");
+    assert.equal(childRewindOps.length, 1);
+    assert.deepEqual(childRewindOps[0]?.data, {
+      v: 2,
+      snapshots: [undoCommit, currentCommit],
+      current: 0,
+      undo: 1,
+    });
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("session_before_fork gracefully cancels when restore fails", async () => {
+  const harness = await createHarness({
+    settings: { rewind: { silentCheckpoints: true } },
+    failGitSubcommands: ["restore"],
+  });
+
+  try {
+    await harness.writeRepoFile("notes.txt", "target state\n");
+    const targetCommit = await harness.captureSnapshot();
+    await harness.writeRepoFile("notes.txt", "current state\n");
+
+    harness.currentSession.replaceEntries([
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: { role: "user", content: [{ type: "text", text: "Restore from here" }] },
+      },
+      {
+        type: "custom",
+        id: "rewind-turn-1",
+        parentId: "user-1",
+        timestamp: new Date().toISOString(),
+        customType: "rewind-turn",
+        data: { v: 2, snapshots: [targetCommit], bindings: [["user-1", 0]] },
+      },
+    ]);
+
+    await harness.invoke("session_start", {});
+    harness.enqueueSelection("Restore all (files + conversation)");
+
+    const result = await harness.invoke("session_before_fork", { entryId: "user-1" });
+    assert.deepEqual(result, { cancel: true });
+    assert.equal(
+      harness.notifications.some((entry) => entry.level === "error" && entry.message.includes("Rewind failed before fork")),
+      true,
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("session_before_tree gracefully cancels when restore fails", async () => {
+  const harness = await createHarness({
+    settings: { rewind: { silentCheckpoints: true } },
+    failGitSubcommands: ["restore"],
+  });
+
+  try {
+    await harness.writeRepoFile("notes.txt", "target state\n");
+    const targetCommit = await harness.captureSnapshot();
+    await harness.writeRepoFile("notes.txt", "current state\n");
+
+    harness.currentSession.replaceEntries([
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        message: { role: "user", content: [{ type: "text", text: "Tree target" }] },
+      },
+      {
+        type: "custom",
+        id: "rewind-turn-1",
+        parentId: "user-1",
+        timestamp: new Date().toISOString(),
+        customType: "rewind-turn",
+        data: { v: 2, snapshots: [targetCommit], bindings: [["user-1", 0]] },
+      },
+    ]);
+
+    await harness.invoke("session_start", {});
+    harness.enqueueSelection("Restore files to that point");
+
+    const result = await harness.invoke("session_before_tree", { preparation: { targetId: "user-1" } });
+    assert.deepEqual(result, { cancel: true });
+    assert.equal(
+      harness.notifications.some((entry) => entry.level === "error" && entry.message.includes("Rewind failed before tree navigation")),
+      true,
+    );
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("first mutating turn creates a reachable store ref even when retention is omitted", async () => {
+  const harness = await createHarness({
+    settings: { rewind: { silentCheckpoints: true } },
+  });
+
+  try {
+    const assistantTimestamp = Date.now();
+    harness.currentSession.replaceEntries([
+      {
+        type: "message",
+        id: "user-1",
+        parentId: null,
+        timestamp: new Date(assistantTimestamp - 1000).toISOString(),
+        message: { role: "user", content: [{ type: "text", text: "Please create the file" }] },
+      },
+      {
+        type: "message",
+        id: "assistant-1",
+        parentId: "user-1",
+        timestamp: new Date(assistantTimestamp).toISOString(),
+        message: {
+          role: "assistant",
+          timestamp: assistantTimestamp,
+          content: [{ type: "text", text: "Created the file" }],
+        },
+      },
+    ]);
+
+    await harness.invoke("session_start", {});
+    await harness.invoke("before_agent_start", { prompt: "Please create the file" });
+    await harness.invoke("turn_start", { turnIndex: 0 });
+    await harness.writeRepoFile("tests/rewind-smoke/a.txt", "smoke test\n");
+    await harness.invoke("turn_end", {
+      message: {
+        role: "assistant",
+        timestamp: assistantTimestamp,
+        content: [{ type: "text", text: "Created the file" }],
+      },
+    });
+    await harness.invoke("agent_end", {});
+
+    const rewindTurnEntries = harness.currentSession.getEntries().filter((entry) => entry.type === "custom" && entry.customType === "rewind-turn");
+    assert.equal(rewindTurnEntries.length, 1);
+    const snapshots = (rewindTurnEntries[0]?.data as { snapshots: string[] }).snapshots;
+    assert.equal(snapshots.length, 2);
+
+    const storeHead = await harness.revParseStore();
+    assert.ok(storeHead);
+    assert.equal(await harness.isAncestor(snapshots[0], storeHead), true);
+    assert.equal(await harness.isAncestor(snapshots[1], storeHead), true);
+
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("startup does not touch the keepalive ref when rewind.retention is omitted", async () => {
+  const harness = await createHarness({ settings: { rewind: { silentCheckpoints: true } } });
+
+  try {
+    await harness.writeRepoFile("tracked.txt", "keepalive\n");
+    const snapshotCommit = await harness.captureSnapshot();
+    await harness.updateStoreRef(snapshotCommit);
+
+    await harness.invoke("session_start", {});
+
+    assert.equal(await harness.revParseStore(), snapshotCommit);
+    assert.equal(harness.execCalls.some((call) => call[0] === "git" && call[1] === "gc"), false);
+    assert.equal(harness.execCalls.some((call) => call[0] === "git" && call[1] === "update-ref" && call.includes(STORE_REF)), false);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("retention preserves the keepalive ref when discovery yields an empty live set", async () => {
+  const harness = await createHarness({ settings: { rewind: { retention: { maxSnapshots: 10 } } } });
+
+  try {
+    await harness.writeRepoFile("tracked.txt", "keepalive\n");
+    const snapshotCommit = await harness.captureSnapshot();
+    await harness.updateStoreRef(snapshotCommit);
+
+    await harness.invoke("session_start", {});
+
+    assert.equal(await harness.revParseStore(), snapshotCommit);
+    assert.equal(harness.execCalls.some((call) => call[0] === "git" && call[1] === "gc"), false);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("ancestor-only retention discovery ignores unrelated session trees", async () => {
+  const harness = await createHarness({
+    settings: { rewind: { retention: { maxSnapshots: 10, scanMode: "ancestor-only" } } },
+  });
+
+  try {
+    await harness.writeRepoFile("tracked.txt", "stale state\n");
+    const staleCommit = await harness.captureSnapshot();
+    await harness.writeRepoFile("tracked.txt", "unrelated live state\n");
+    const unrelatedLiveCommit = await harness.captureSnapshot();
+    await harness.updateStoreRef(staleCommit);
+
+    const unrelatedSession = harness.createSession({
+      id: "session-unrelated",
+      entries: [
+        {
+          type: "custom",
+          id: "rewind-op-1",
+          parentId: null,
+          timestamp: new Date().toISOString(),
+          customType: "rewind-op",
+          data: { v: 2, snapshots: [unrelatedLiveCommit], current: 0 },
+        },
+      ],
+    });
+    unrelatedSession.flush();
+
+    await harness.invoke("session_start", {});
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    assert.equal(await harness.revParseStore(), staleCommit);
+  } finally {
+    await harness.cleanup();
+  }
+});
+
+test("retention rewrites the keepalive ref when a live snapshot exists", async () => {
+  const harness = await createHarness({
+    settings: { rewind: { retention: { maxSnapshots: 10 } } },
+  });
+
+  try {
+    await harness.writeRepoFile("tracked.txt", "stale state\n");
+    const staleCommit = await harness.captureSnapshot();
+    await harness.writeRepoFile("tracked.txt", "current live state\n");
+    const liveCommit = await harness.captureSnapshot();
+    assert.notEqual(liveCommit, staleCommit);
+    await harness.updateStoreRef(staleCommit);
+
+    harness.currentSession.replaceEntries([
+      {
+        type: "custom",
+        id: "rewind-op-1",
+        parentId: null,
+        timestamp: new Date().toISOString(),
+        customType: "rewind-op",
+        data: { v: 2, snapshots: [liveCommit], current: 0 },
+      },
+    ]);
+
+    await harness.invoke("session_start", {});
+
+    // Retention sweep runs in the background on startup; poll for completion
+    const deadline = Date.now() + 3000;
+    let storeHead: string | undefined;
+    while (Date.now() < deadline) {
+      storeHead = await harness.revParseStore();
+      if (storeHead && await harness.isAncestor(liveCommit, storeHead)) break;
+      await new Promise(r => setTimeout(r, 50));
+    }
+    assert.ok(storeHead);
+    assert.equal(await harness.isAncestor(liveCommit, storeHead!), true);
+  } finally {
+    await harness.cleanup();
+  }
+});
+

--- a/index.ts
+++ b/index.ts
@@ -1,610 +1,1366 @@
 /**
- * Rewind Extension - Git-based file restoration for pi branching
+ * Rewind Extension - session-ledger based exact file restoration for pi branching
  *
- * Creates worktree snapshots at the start of each agent loop (when user sends a message)
- * so /fork and /tree navigation can restore code state.
- * Supports: restore files + conversation, files only, conversation only, undo last restore.
- *
- * Updated for pi-coding-agent v0.35.0+ (unified extensions system)
+ * Rewind v2 stores exact rewind metadata in hidden session custom entries and keeps
+ * snapshot commits reachable through a single repo-local store ref.
  */
 
-import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+import { getAgentDir, type ExtensionAPI, type ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { exec as execCb } from "child_process";
-import { readFileSync } from "fs";
-import { mkdtemp, rm } from "fs/promises";
-import { homedir, tmpdir } from "os";
-import { join } from "path";
+import { existsSync, readFileSync, realpathSync } from "fs";
+import { mkdtemp, readdir, readFile, rm, stat } from "fs/promises";
+import { tmpdir } from "os";
+import { dirname, isAbsolute, join, relative, resolve } from "path";
 import { promisify } from "util";
 
 const execAsync = promisify(execCb);
 
-const REF_PREFIX = "refs/pi-checkpoints/";
-const BEFORE_RESTORE_PREFIX = "before-restore-";
-const MAX_CHECKPOINTS = 100;
+const STORE_REF = "refs/pi-rewind/store";
 const STATUS_KEY = "rewind";
-const SETTINGS_FILE = join(homedir(), ".pi", "agent", "settings.json");
+const FORK_PREFERENCE_SOURCE_ALLOWLIST = new Set(["fork-from-first"]);
+const LEGACY_ZERO_SHA = "0000000000000000000000000000000000000000";
+const RETENTION_SWEEP_THRESHOLD = 50;
+const RETENTION_VERSION = 2;
+const EMPTY_TREE_SHA = "4b825dc642cb6eb9a060e54bf8d69288fbee4904";
 
 type ExecFn = (cmd: string, args: string[]) => Promise<{ stdout: string; stderr: string; code: number }>;
 
-let cachedSilentCheckpoints: boolean | null = null;
+type GitExecResult = Awaited<ReturnType<ExecFn>>;
+
+type BindingTuple = [entryId: string, snapshotIndex: number];
+
+interface RewindSettings {
+  rewind?: {
+    silentCheckpoints?: boolean;
+    retention?: {
+      maxSnapshots?: number;
+      maxAgeDays?: number;
+      pinLabeledEntries?: boolean;
+      scanMode?: "ancestor-only" | "repo-sessions";
+      startupBudgetMs?: number;
+    };
+  };
+}
+
+type RewindRetentionSettings = NonNullable<NonNullable<RewindSettings["rewind"]>["retention"]>;
+
+interface RewindTurnData {
+  v: 2;
+  snapshots: string[];
+  bindings: BindingTuple[];
+}
+
+interface RewindOpData {
+  v: 2;
+  snapshots: string[];
+  bindings?: BindingTuple[];
+  current?: number;
+  undo?: number;
+}
+
+interface ActivePromptCollector {
+  snapshots: string[];
+  bindings: BindingTuple[];
+  promptText?: string;
+  pendingUserCommitSha?: string;
+}
+
+interface ExactState {
+  commitSha: string;
+  treeSha: string;
+}
+
+interface ActiveBranchState {
+  currentCommitSha?: string;
+  currentTreeSha?: string;
+  undoCommitSha?: string;
+}
+
+interface PendingResultingState {
+  currentCommitSha: string;
+  undoCommitSha?: string;
+}
+
+interface ParsedLedgerReference {
+  commitSha: string;
+  entryId?: string;
+  timestamp: number;
+  kind: "binding" | "current" | "undo";
+}
+
+interface ParsedSessionLedger {
+  sessionFile: string;
+  sessionId?: string;
+  cwd?: string;
+  parentSession?: string;
+  entryToCommit: Map<string, string>;
+  labeledEntryIds: Set<string>;
+  references: ParsedLedgerReference[];
+  latestCurrentCommitSha?: string;
+  latestUndoCommitSha?: string;
+}
+
+interface SessionLikeMessageEntry {
+  type: "message";
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  message: {
+    role: string;
+    timestamp?: number;
+    content?: unknown;
+  };
+}
+
+interface SessionLikeCustomEntry {
+  type: "custom";
+  id: string;
+  parentId: string | null;
+  timestamp: string;
+  customType: string;
+  data?: unknown;
+}
+
+interface SessionLikeLabelEntry {
+  type: "label";
+  targetId: string;
+  label?: string;
+}
+
+interface SessionLikeBranchSummaryEntry {
+  type: "branch_summary";
+  id: string;
+}
+
+interface SessionLikeGenericEntry {
+  type: string;
+  id?: string;
+  parentId?: string | null;
+  timestamp?: string;
+  message?: {
+    role?: string;
+    timestamp?: number;
+    content?: unknown;
+  };
+  customType?: string;
+  data?: unknown;
+  targetId?: string;
+  label?: string;
+}
+
+type SessionLikeEntry =
+  | SessionLikeMessageEntry
+  | SessionLikeCustomEntry
+  | SessionLikeLabelEntry
+  | SessionLikeBranchSummaryEntry
+  | SessionLikeGenericEntry;
+
+let cachedSettings: RewindSettings | null = null;
+
+function getSettingsFilePath(): string {
+  return join(getAgentDir(), "settings.json");
+}
+
+function getDefaultSessionsDir(): string {
+  return join(getAgentDir(), "sessions");
+}
+
+function getSettings(): RewindSettings {
+  if (cachedSettings) {
+    return cachedSettings;
+  }
+
+  try {
+    cachedSettings = JSON.parse(readFileSync(getSettingsFilePath(), "utf-8")) as RewindSettings;
+  } catch {
+    // Invalid/missing settings must not disable rewind; fall back to defaults.
+    cachedSettings = {};
+  }
+
+  return cachedSettings;
+}
 
 function getSilentCheckpointsSetting(): boolean {
-  if (cachedSilentCheckpoints !== null) {
-    return cachedSilentCheckpoints;
+  return getSettings().rewind?.silentCheckpoints === true;
+}
+
+function getRetentionSettings(): RewindRetentionSettings | undefined {
+  return getSettings().rewind?.retention;
+}
+
+function getRetentionScanMode(): "ancestor-only" | "repo-sessions" {
+  return getRetentionSettings()?.scanMode === "repo-sessions" ? "repo-sessions" : "ancestor-only";
+}
+
+function getStartupSweepBudgetMs(): number | undefined {
+  const value = getRetentionSettings()?.startupBudgetMs;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return undefined;
   }
+  return value;
+}
+
+function isRewindTurnData(value: unknown): value is RewindTurnData {
+  if (!value || typeof value !== "object") return false;
+  const data = value as Partial<RewindTurnData>;
+  return data.v === 2 && Array.isArray(data.snapshots) && Array.isArray(data.bindings);
+}
+
+function isRewindOpData(value: unknown): value is RewindOpData {
+  if (!value || typeof value !== "object") return false;
+  const data = value as Partial<RewindOpData>;
+  return data.v === 2 && Array.isArray(data.snapshots);
+}
+
+function canonicalizePath(value: string): string {
+  const resolvedValue = resolve(value);
   try {
-    const settingsContent = readFileSync(SETTINGS_FILE, "utf-8");
-    const settings = JSON.parse(settingsContent);
-    cachedSilentCheckpoints = settings.rewind?.silentCheckpoints === true;
-    return cachedSilentCheckpoints;
+    return realpathSync.native(resolvedValue);
   } catch {
-    cachedSilentCheckpoints = false;
-    return false;
+    // Path may not exist yet; compare with the resolved path directly.
+    return resolvedValue;
   }
 }
 
-/**
- * Sanitize entry ID for use in git ref names.
- * Git refs can't contain: space, ~, ^, :, ?, *, [, \, or control chars.
- * Entry IDs are typically alphanumeric but we sanitize just in case.
- */
-function sanitizeForRef(id: string): string {
-  return id.replace(/[^a-zA-Z0-9-]/g, "_");
+function isInsidePath(targetPath: string, parentPath: string): boolean {
+  const resolvedTarget = canonicalizePath(targetPath);
+  const resolvedParent = canonicalizePath(parentPath);
+  const rel = relative(resolvedParent, resolvedTarget);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }
 
-export default function (pi: ExtensionAPI) {
-  const checkpoints = new Map<string, string>();
-  let resumeCheckpoint: string | null = null;
+function toTimestamp(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function getTextContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((block): block is { type: string; text?: string } => !!block && typeof block === "object")
+    .filter((block) => block.type === "text")
+    .map((block) => block.text ?? "")
+    .join("\n");
+}
+
+function updateLabelSet(labelIds: Set<string>, entry: SessionLikeLabelEntry) {
+  if (!entry.targetId) return;
+  if (entry.label && entry.label.trim()) {
+    labelIds.add(entry.targetId);
+    return;
+  }
+  labelIds.delete(entry.targetId);
+}
+
+function applyBindings(target: Map<string, string>, snapshots: string[], bindings?: BindingTuple[]) {
+  if (!bindings) return;
+  for (const [entryId, snapshotIndex] of bindings) {
+    const commitSha = snapshots[snapshotIndex];
+    if (entryId && commitSha) {
+      target.set(entryId, commitSha);
+    }
+  }
+}
+
+function addReferences(target: ParsedLedgerReference[], snapshots: string[], timestamp: number, data: RewindTurnData | RewindOpData) {
+  if ("bindings" in data && data.bindings) {
+    for (const [entryId, snapshotIndex] of data.bindings) {
+      const commitSha = snapshots[snapshotIndex];
+      if (!commitSha) continue;
+      target.push({ commitSha, entryId, timestamp, kind: "binding" });
+    }
+  }
+
+  if ("current" in data && typeof data.current === "number") {
+    const commitSha = snapshots[data.current];
+    if (commitSha) {
+      target.push({ commitSha, timestamp, kind: "current" });
+    }
+  }
+
+  if ("undo" in data && typeof data.undo === "number") {
+    const commitSha = snapshots[data.undo];
+    if (commitSha) {
+      target.push({ commitSha, timestamp, kind: "undo" });
+    }
+  }
+}
+
+function resolveBindingSnapshotIndex(snapshots: string[], commitSha: string): number {
+  const existingIndex = snapshots.indexOf(commitSha);
+  if (existingIndex >= 0) return existingIndex;
+  snapshots.push(commitSha);
+  return snapshots.length - 1;
+}
+
+function addBindingToCollector(collector: ActivePromptCollector, entryId: string, commitSha: string) {
+  const snapshotIndex = resolveBindingSnapshotIndex(collector.snapshots, commitSha);
+  collector.bindings.push([entryId, snapshotIndex]);
+}
+
+function getCommitFromData(data: RewindOpData, indexKey: "current" | "undo"): string | undefined {
+  const snapshotIndex = data[indexKey];
+  return typeof snapshotIndex === "number" ? data.snapshots[snapshotIndex] : undefined;
+}
+
+function isRestorableTreeEntry(entry: SessionLikeEntry | undefined): boolean {
+  if (!entry) return false;
+  if (entry.type === "message") {
+    return entry.message.role === "user" || entry.message.role === "assistant";
+  }
+  return entry.type === "branch_summary" || entry.type === "compaction";
+}
+
+function isAssistantMessageEntry(entry: SessionLikeEntry): entry is SessionLikeMessageEntry {
+  return entry.type === "message" && entry.message.role === "assistant";
+}
+
+function findLatestUserMessageEntry(entries: SessionLikeEntry[]): SessionLikeMessageEntry | null {
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type === "message" && entry.message.role === "user") {
+      return entry;
+    }
+  }
+  return null;
+}
+
+function findLatestMatchingUserMessageEntry(
+  entries: SessionLikeEntry[],
+  promptText: string | null | undefined,
+): SessionLikeMessageEntry | null {
+  if (!promptText) return null;
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (entry.type !== "message" || entry.message.role !== "user") continue;
+    if (getTextContent(entry.message.content) === promptText) {
+      return entry;
+    }
+  }
+
+  return null;
+}
+
+function findAssistantEntryForTurn(entries: SessionLikeEntry[], message: { timestamp?: number; content?: unknown }): SessionLikeMessageEntry | null {
+  const targetTimestamp = message.timestamp;
+  const targetText = getTextContent(message.content);
+
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const entry = entries[index];
+    if (!isAssistantMessageEntry(entry)) continue;
+
+    if (targetTimestamp !== undefined && entry.message.timestamp === targetTimestamp) {
+      return entry;
+    }
+
+    if (targetText && getTextContent(entry.message.content) === targetText) {
+      return entry;
+    }
+  }
+
+  return null;
+}
+
+export default function rewindExtension(pi: ExtensionAPI) {
+  const entryToCommit = new Map<string, string>();
+  const parsedSessionCache = new Map<string, { mtimeMs: number; ledger: ParsedSessionLedger }>();
+
   let repoRoot: string | null = null;
-  let isGitRepo = false;
   let sessionId: string | null = null;
-  
-  // Pending checkpoint: worktree state captured at turn_start, waiting for turn_end
-  // to associate with the correct user message entry ID
-  let pendingCheckpoint: { commitSha: string; timestamp: number } | null = null;
-  
-  /**
-   * Update the footer status with checkpoint count
-   */
+  let currentSessionFile: string | undefined;
+  let currentParentSession: string | undefined;
+  let currentSessionCwd: string | undefined;
+  let isGitRepo = false;
+  let lastExact: ExactState | null = null;
+  let activeBranchState: ActiveBranchState = {};
+  let promptCollector: ActivePromptCollector | null = null;
+  let pendingForkState: PendingResultingState | null = null;
+  let pendingTreeState: PendingResultingState | null = null;
+  let activePromptText: string | null = null;
+    let newSnapshotsSinceSweep = 0;
+    let sweepRunning = false;
+    let sweepCompletedThisSession = false;
+  let forceConversationOnlyOnNextFork = false;
+  let forceConversationOnlySource: string | null = null;
+
+  function notify(ctx: ExtensionContext, message: string, level: "info" | "warning" | "error" = "info") {
+    if (!ctx.hasUI) return;
+    if (level === "info" && getSilentCheckpointsSetting()) return;
+    ctx.ui.notify(message, level);
+  }
+
   function updateStatus(ctx: ExtensionContext) {
     if (!ctx.hasUI) return;
-    if (getSilentCheckpointsSetting()) {
+    if (!isGitRepo || getSilentCheckpointsSetting()) {
       ctx.ui.setStatus(STATUS_KEY, undefined);
       return;
     }
+
+    const uniqueSnapshots = new Set(entryToCommit.values()).size;
     const theme = ctx.ui.theme;
-    const count = checkpoints.size;
-    ctx.ui.setStatus(STATUS_KEY, theme.fg("dim", "◆ ") + theme.fg("muted", `${count} checkpoint${count === 1 ? "" : "s"}`));
+    ctx.ui.setStatus(
+      STATUS_KEY,
+      theme.fg("dim", "◆ ") + theme.fg("muted", `${entryToCommit.size} points / ${uniqueSnapshots} snapshots`),
+    );
   }
-  
-  /**
-   * Reset all state for a fresh session
-   */
+
   function resetState() {
-    checkpoints.clear();
-    resumeCheckpoint = null;
+    entryToCommit.clear();
+    parsedSessionCache.clear();
     repoRoot = null;
-    isGitRepo = false;
     sessionId = null;
-    pendingCheckpoint = null;
-    cachedSilentCheckpoints = null;
+    currentSessionFile = undefined;
+    currentParentSession = undefined;
+    currentSessionCwd = undefined;
+    isGitRepo = false;
+    lastExact = null;
+    activeBranchState = {};
+    promptCollector = null;
+    pendingForkState = null;
+    pendingTreeState = null;
+      activePromptText = null;
+      newSnapshotsSinceSweep = 0;
+      sweepCompletedThisSession = false;
+    forceConversationOnlyOnNextFork = false;
+    forceConversationOnlySource = null;
+    cachedSettings = null;
   }
 
-  /**
-   * Rebuild the checkpoints map from existing git refs.
-   * Supports two formats for backward compatibility:
-   * - New format: `checkpoint-{sessionId}-{timestamp}-{entryId}` (session-scoped)
-   * - Old format: `checkpoint-{timestamp}-{entryId}` (pre-v1.7.0, loaded for current session)
-   * This allows checkpoint restoration to work across session resumes.
-   */
-  async function rebuildCheckpointsMap(exec: ExecFn, currentSessionId: string): Promise<void> {
-    try {
-      const result = await exec("git", [
-        "for-each-ref",
-        "--sort=-creatordate",  // Newest first - we keep first match per entry
-        "--format=%(refname)",
-        REF_PREFIX,
-      ]);
-
-      const refs = result.stdout.trim().split("\n").filter(Boolean);
-
-      for (const ref of refs) {
-        // Get checkpoint ID by removing prefix
-        const checkpointId = ref.replace(REF_PREFIX, "");
-
-        // Skip non-checkpoint refs (before-restore, resume)
-        if (!checkpointId.startsWith("checkpoint-")) continue;
-        if (checkpointId.startsWith("checkpoint-resume-")) continue;
-
-        // Try new format first: checkpoint-{sessionId}-{timestamp}-{entryId}
-        // Session ID is a UUID (36 chars with hyphens)
-        // Timestamp is always numeric (13 digits for ms since epoch)
-        // Entry ID comes after the timestamp, may contain hyphens
-        const newFormatMatch = checkpointId.match(/^checkpoint-([a-f0-9-]{36})-(\d+)-(.+)$/);
-        if (newFormatMatch) {
-          const refSessionId = newFormatMatch[1];
-          const entryId = newFormatMatch[3];
-          // Only load checkpoints from the current session, keep newest (first seen)
-          if (refSessionId === currentSessionId && !checkpoints.has(entryId)) {
-            checkpoints.set(entryId, checkpointId);
-          }
-          continue;
-        }
-
-        // Try old format: checkpoint-{timestamp}-{entryId} (pre-v1.7.0)
-        // Load these for backward compatibility - they belong to whoever resumes the session
-        const oldFormatMatch = checkpointId.match(/^checkpoint-(\d+)-(.+)$/);
-        if (oldFormatMatch) {
-          const entryId = oldFormatMatch[2];
-          // Keep newest (first seen), prefer new-format if exists
-          if (!checkpoints.has(entryId)) {
-            checkpoints.set(entryId, checkpointId);
-          }
-        }
-      }
-
-    } catch {
-      // Silent failure - checkpoints will be recreated as needed
-    }
+  function syncSessionIdentity(ctx: ExtensionContext) {
+    sessionId = ctx.sessionManager.getSessionId();
+    currentSessionFile = ctx.sessionManager.getSessionFile();
+    currentParentSession = ctx.sessionManager.getHeader()?.parentSession;
+    currentSessionCwd = ctx.sessionManager.getCwd();
   }
 
-  async function findBeforeRestoreRef(exec: ExecFn, currentSessionId: string): Promise<{ refName: string; commitSha: string } | null> {
-    try {
-      // Look for before-restore refs scoped to this session
-      const result = await exec("git", [
-        "for-each-ref",
-        "--sort=-creatordate",
-        "--count=1",
-        "--format=%(refname) %(objectname)",
-        `${REF_PREFIX}${BEFORE_RESTORE_PREFIX}${currentSessionId}-*`,
-      ]);
-
-      const line = result.stdout.trim();
-      if (!line) return null;
-
-      const parts = line.split(" ");
-      if (parts.length < 2 || !parts[0] || !parts[1]) return null;
-      return { refName: parts[0], commitSha: parts[1] };
-    } catch {
-      return null;
+  async function execGitChecked(args: string[]): Promise<GitExecResult> {
+    const result = await pi.exec("git", args);
+    if (result.code !== 0) {
+      const stderr = result.stderr.trim();
+      throw new Error(stderr || `git ${args.join(" ")} failed with code ${result.code}`);
     }
+    return result;
   }
 
   async function getRepoRoot(exec: ExecFn): Promise<string> {
     if (repoRoot) return repoRoot;
     const result = await exec("git", ["rev-parse", "--show-toplevel"]);
+    if (result.code !== 0) {
+      const stderr = result.stderr.trim();
+      throw new Error(stderr || `git rev-parse --show-toplevel failed with code ${result.code}`);
+    }
     repoRoot = result.stdout.trim();
     return repoRoot;
   }
 
-  /**
-   * Capture current worktree state as a git commit (without affecting HEAD).
-   * Uses execAsync directly (instead of pi.exec) because we need to set
-   * GIT_INDEX_FILE environment variable for an isolated index.
-   */
-  async function captureWorktree(): Promise<string> {
+  async function captureWorktreeTree(): Promise<{ treeSha: string }> {
     const root = await getRepoRoot(pi.exec);
-    const tmpDir = await mkdtemp(join(tmpdir(), "pi-rewind-"));
-    const tmpIndex = join(tmpDir, "index");
+    const tempDir = await mkdtemp(join(tmpdir(), "pi-rewind-"));
+    const tempIndex = join(tempDir, "index");
 
     try {
-      const env = { ...process.env, GIT_INDEX_FILE: tmpIndex };
+      const env = { ...process.env, GIT_INDEX_FILE: tempIndex };
       await execAsync("git add -A", { cwd: root, env });
-      const { stdout: treeSha } = await execAsync("git write-tree", { cwd: root, env });
-
-      const result = await pi.exec("git", ["commit-tree", treeSha.trim(), "-m", "rewind backup"]);
-      return result.stdout.trim();
+      const { stdout } = await execAsync("git write-tree", { cwd: root, env });
+      return { treeSha: stdout.trim() };
     } finally {
-      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-    }
-  }
-
-  async function restoreWithBackup(
-    exec: ExecFn,
-    targetRef: string,
-    currentSessionId: string,
-    notify: (msg: string, level: "info" | "warning" | "error") => void
-  ): Promise<boolean> {
-    try {
-      const existingBackup = await findBeforeRestoreRef(exec, currentSessionId);
-
-      const backupCommit = await captureWorktree();
-      // Include session ID in before-restore ref to scope it per-session
-      const newBackupId = `${BEFORE_RESTORE_PREFIX}${currentSessionId}-${Date.now()}`;
-      await exec("git", [
-        "update-ref",
-        `${REF_PREFIX}${newBackupId}`,
-        backupCommit,
-      ]);
-
-      if (existingBackup) {
-        await exec("git", ["update-ref", "-d", existingBackup.refName]);
-      }
-
-      await exec("git", ["checkout", targetRef, "--", "."]);
-      return true;
-    } catch (err) {
-      notify(`Failed to restore: ${err}`, "error");
-      return false;
-    }
-  }
-
-  async function createCheckpointFromWorktree(exec: ExecFn, checkpointId: string): Promise<boolean> {
-    try {
-      const commitSha = await captureWorktree();
-      await exec("git", [
-        "update-ref",
-        `${REF_PREFIX}${checkpointId}`,
-        commitSha,
-      ]);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
-  /**
-   * Find the most recent user message in the current branch.
-   * Used at turn_end to find the user message that triggered the agent loop.
-   */
-  function findUserMessageEntry(sessionManager: { getLeafId(): string | null; getBranch(id?: string): any[] }): { id: string } | null {
-    const leafId = sessionManager.getLeafId();
-    if (!leafId) return null;
-    
-    const branch = sessionManager.getBranch(leafId);
-    // Walk backwards to find the most recent user message
-    for (let i = branch.length - 1; i >= 0; i--) {
-      const entry = branch[i];
-      if (entry.type === "message" && entry.message?.role === "user") {
-        return entry;
-      }
-    }
-    return null;
-  }
-
-  async function pruneCheckpoints(exec: ExecFn, currentSessionId: string) {
-    try {
-      const result = await exec("git", [
-        "for-each-ref",
-        "--sort=creatordate",
-        "--format=%(refname)",
-        REF_PREFIX,
-      ]);
-
-      const refs = result.stdout.trim().split("\n").filter(Boolean);
-      // Filter to only regular checkpoints from THIS session (not backups, resume, or other sessions)
-      const checkpointRefs = refs.filter(r => {
-        if (r.includes(BEFORE_RESTORE_PREFIX)) return false;
-        if (r.includes("checkpoint-resume-")) return false;
-        // Only include refs from current session
-        const checkpointId = r.replace(REF_PREFIX, "");
-        return checkpointId.startsWith(`checkpoint-${currentSessionId}-`);
+      await rm(tempDir, { recursive: true, force: true }).catch(() => {
+        // Best effort cleanup for temporary index directory.
       });
+    }
+  }
 
-      if (checkpointRefs.length > MAX_CHECKPOINTS) {
-        const toDelete = checkpointRefs.slice(0, checkpointRefs.length - MAX_CHECKPOINTS);
-        for (const ref of toDelete) {
-          await exec("git", ["update-ref", "-d", ref]);
+  async function getCommitTreeSha(commitSha: string): Promise<string> {
+    const result = await execGitChecked(["show", "-s", "--format=%T", commitSha]);
+    return result.stdout.trim();
+  }
 
-          // Remove from in-memory map ONLY if this is the currently mapped checkpoint.
-          // There might be a newer checkpoint for the same entry that we're keeping.
-          const checkpointId = ref.replace(REF_PREFIX, "");
-          const match = checkpointId.match(/^checkpoint-([a-f0-9-]{36})-(\d+)-(.+)$/);
-          if (match) {
-            const entryId = match[3];
-            if (checkpoints.get(entryId) === checkpointId) {
-              checkpoints.delete(entryId);
+  async function commitExists(commitSha: string): Promise<boolean> {
+    const result = await pi.exec("git", ["cat-file", "-e", `${commitSha}^{commit}`]);
+    return result.code === 0;
+  }
+
+  async function getStoreHead(): Promise<string | undefined> {
+    const result = await pi.exec("git", ["rev-parse", "--verify", STORE_REF]);
+    if (result.code !== 0) {
+      return undefined;
+    }
+    const value = result.stdout.trim();
+    return value || undefined;
+  }
+
+  async function createStoreKeepaliveCommit(snapshotCommitSha: string, previousStoreHead?: string): Promise<string> {
+    const args = ["commit-tree", EMPTY_TREE_SHA];
+
+    if (previousStoreHead) {
+      args.push("-p", previousStoreHead);
+    }
+
+    args.push("-p", snapshotCommitSha, "-m", "pi rewind store");
+    const result = await execGitChecked(args);
+    return result.stdout.trim();
+  }
+
+  async function appendSnapshotToStore(commitSha: string): Promise<void> {
+    let attempts = 0;
+    let lastError: unknown;
+
+    while (attempts < 5) {
+      attempts += 1;
+      const oldHead = await getStoreHead();
+      const keepaliveCommit = await createStoreKeepaliveCommit(commitSha, oldHead);
+
+      try {
+        if (oldHead) {
+          await execGitChecked(["update-ref", STORE_REF, keepaliveCommit, oldHead]);
+        } else {
+          await execGitChecked(["update-ref", STORE_REF, keepaliveCommit, LEGACY_ZERO_SHA]);
+        }
+        return;
+      } catch (error) {
+        // Retry if another process updated the store ref concurrently.
+        // Keep the most recent error for actionable failure context.
+        lastError = error;
+      }
+    }
+
+    const detail = lastError instanceof Error ? lastError.message : String(lastError);
+    throw new Error(`failed to update rewind store ref: ${detail}`);
+  }
+
+  async function rewriteStoreToLiveSet(liveCommitShas: string[]): Promise<"rewritten" | "preserved-empty"> {
+    const uniqueLiveCommits = [...new Set(liveCommitShas.filter(Boolean))];
+    if (uniqueLiveCommits.length === 0) {
+      return "preserved-empty";
+    }
+
+    let head: string | undefined;
+    for (const commitSha of uniqueLiveCommits) {
+      head = await createStoreKeepaliveCommit(commitSha, head);
+    }
+
+    const oldHead = await getStoreHead();
+    if (oldHead) {
+      await execGitChecked(["update-ref", STORE_REF, head!, oldHead]);
+      return "rewritten";
+    }
+
+    await execGitChecked(["update-ref", STORE_REF, head!, LEGACY_ZERO_SHA]);
+    return "rewritten";
+  }
+
+  async function ensureSnapshotForTree(treeSha: string): Promise<string> {
+    if (lastExact && lastExact.treeSha === treeSha) {
+      return lastExact.commitSha;
+    }
+
+    const result = await execGitChecked(["commit-tree", treeSha, "-m", "pi rewind snapshot"]);
+    const commitSha = result.stdout.trim();
+    await appendSnapshotToStore(commitSha);
+    lastExact = { commitSha, treeSha };
+    newSnapshotsSinceSweep += 1;
+    return commitSha;
+  }
+
+  async function ensureSnapshotForCurrentWorktree(): Promise<string> {
+    const { treeSha } = await captureWorktreeTree();
+    return ensureSnapshotForTree(treeSha);
+  }
+
+  async function deletePathsFromWorkingTree(paths: string[]) {
+    if (paths.length === 0) return;
+    const root = await getRepoRoot(pi.exec);
+
+    for (const repoRelativePath of paths) {
+      const absolutePath = resolve(root, repoRelativePath);
+      if (!isInsidePath(absolutePath, root)) {
+        throw new Error(`refusing to delete path outside repo root: ${repoRelativePath}`);
+      }
+      await rm(absolutePath, { recursive: true, force: true });
+    }
+  }
+
+  async function getDeletedPaths(currentTreeSha: string, targetTreeSha: string): Promise<string[]> {
+    const result = await execGitChecked([
+      "diff",
+      "--name-only",
+      "--diff-filter=D",
+      "-z",
+      currentTreeSha,
+      targetTreeSha,
+      "--",
+    ]);
+
+    return result.stdout.split("\0").filter(Boolean);
+  }
+
+  async function restoreCommitExactly(targetCommitSha: string): Promise<{ changed: boolean; undoCommitSha?: string; targetTreeSha: string }> {
+    const { treeSha: currentTreeSha } = await captureWorktreeTree();
+    const targetTreeSha = await getCommitTreeSha(targetCommitSha);
+
+    if (currentTreeSha === targetTreeSha) {
+      lastExact = { commitSha: targetCommitSha, treeSha: targetTreeSha };
+      return { changed: false, targetTreeSha };
+    }
+
+    const undoCommitSha = await ensureSnapshotForTree(currentTreeSha);
+    const pathsToDelete = await getDeletedPaths(currentTreeSha, targetTreeSha);
+    await deletePathsFromWorkingTree(pathsToDelete);
+    await execGitChecked(["restore", `--source=${targetCommitSha}`, "--worktree", "--", "."]);
+    lastExact = { commitSha: targetCommitSha, treeSha: targetTreeSha };
+    return { changed: true, undoCommitSha, targetTreeSha };
+  }
+
+  function bindPendingPromptUser(entries: SessionLikeEntry[], collector: ActivePromptCollector) {
+    if (!collector.pendingUserCommitSha) return;
+
+    const userEntry = findLatestMatchingUserMessageEntry(entries, collector.promptText) ?? findLatestUserMessageEntry(entries);
+    if (!userEntry) return;
+    if (collector.bindings.some(([entryId]) => entryId === userEntry.id)) {
+      collector.pendingUserCommitSha = undefined;
+      return;
+    }
+
+    addBindingToCollector(collector, userEntry.id, collector.pendingUserCommitSha);
+    collector.pendingUserCommitSha = undefined;
+  }
+
+  function appendRewindTurn(ctx: ExtensionContext, collector: ActivePromptCollector) {
+    if (collector.bindings.length === 0) return;
+
+    const data: RewindTurnData = {
+      v: RETENTION_VERSION,
+      snapshots: collector.snapshots,
+      bindings: collector.bindings,
+    };
+
+    pi.appendEntry("rewind-turn", data);
+    applyBindings(entryToCommit, data.snapshots, data.bindings);
+
+    const latestBinding = data.bindings[data.bindings.length - 1];
+    if (latestBinding) {
+      activeBranchState.currentCommitSha = data.snapshots[latestBinding[1]];
+      activeBranchState.currentTreeSha = lastExact?.commitSha === activeBranchState.currentCommitSha ? lastExact.treeSha : undefined;
+    }
+
+    updateStatus(ctx);
+  }
+
+  function appendRewindOp(ctx: ExtensionContext, data: RewindOpData) {
+    const hasBindings = Boolean(data.bindings?.length);
+    const hasCurrent = typeof data.current === "number";
+    const hasUndo = typeof data.undo === "number";
+    if (!hasBindings && !hasCurrent && !hasUndo) return;
+
+    pi.appendEntry("rewind-op", data);
+    applyBindings(entryToCommit, data.snapshots, data.bindings);
+
+    const currentCommitSha = getCommitFromData(data, "current");
+    if (currentCommitSha) {
+      activeBranchState.currentCommitSha = currentCommitSha;
+      activeBranchState.currentTreeSha = lastExact?.commitSha === currentCommitSha ? lastExact.treeSha : undefined;
+    }
+
+    const undoCommitSha = getCommitFromData(data, "undo");
+    if (undoCommitSha) {
+      activeBranchState.undoCommitSha = undoCommitSha;
+    }
+
+    updateStatus(ctx);
+  }
+
+  function buildCurrentSessionLedger(ctx: ExtensionContext): ParsedSessionLedger {
+    const ledger: ParsedSessionLedger = {
+      sessionFile: currentSessionFile ?? "",
+      sessionId: ctx.sessionManager.getSessionId(),
+      cwd: ctx.sessionManager.getCwd(),
+      parentSession: ctx.sessionManager.getHeader()?.parentSession,
+      entryToCommit: new Map<string, string>(),
+      labeledEntryIds: new Set<string>(),
+      references: [],
+    };
+
+    for (const rawEntry of ctx.sessionManager.getEntries() as SessionLikeEntry[]) {
+      if (rawEntry.type === "custom" && rawEntry.customType === "rewind-turn" && isRewindTurnData(rawEntry.data)) {
+        applyBindings(ledger.entryToCommit, rawEntry.data.snapshots, rawEntry.data.bindings);
+        addReferences(ledger.references, rawEntry.data.snapshots, toTimestamp(rawEntry.timestamp), rawEntry.data);
+        continue;
+      }
+
+      if (rawEntry.type === "custom" && rawEntry.customType === "rewind-op" && isRewindOpData(rawEntry.data)) {
+        applyBindings(ledger.entryToCommit, rawEntry.data.snapshots, rawEntry.data.bindings);
+        addReferences(ledger.references, rawEntry.data.snapshots, toTimestamp(rawEntry.timestamp), rawEntry.data);
+        const currentCommitSha = getCommitFromData(rawEntry.data, "current");
+        if (currentCommitSha) ledger.latestCurrentCommitSha = currentCommitSha;
+        const undoCommitSha = getCommitFromData(rawEntry.data, "undo");
+        if (undoCommitSha) ledger.latestUndoCommitSha = undoCommitSha;
+        continue;
+      }
+
+      if (rawEntry.type === "label") {
+        updateLabelSet(ledger.labeledEntryIds, rawEntry);
+      }
+    }
+
+    return ledger;
+  }
+
+  async function parseSessionLedgerFile(sessionFile: string): Promise<ParsedSessionLedger | null> {
+    try {
+      const fileStat = await stat(sessionFile);
+      const cached = parsedSessionCache.get(sessionFile);
+      if (cached && cached.mtimeMs === fileStat.mtimeMs) {
+        return cached.ledger;
+      }
+
+      const content = await readFile(sessionFile, "utf-8");
+      const ledger: ParsedSessionLedger = {
+        sessionFile,
+        entryToCommit: new Map<string, string>(),
+        labeledEntryIds: new Set<string>(),
+        references: [],
+      };
+
+      const hasRewindEntries = content.includes('"rewind-');
+
+      if (!hasRewindEntries) {
+        // Fast path: extract session header only, skip line-by-line JSON parsing
+        let pos = 0;
+        for (let i = 0; i < 5 && pos < content.length; i++) {
+          const nextNewline = content.indexOf("\n", pos);
+          const line = nextNewline >= 0 ? content.substring(pos, nextNewline) : content.substring(pos);
+          pos = nextNewline >= 0 ? nextNewline + 1 : content.length;
+          if (!line) continue;
+          try {
+            const entry = JSON.parse(line);
+            if (entry?.type === "session") {
+              ledger.sessionId = entry.id;
+              ledger.cwd = entry.cwd;
+              ledger.parentSession = entry.parentSession;
+              break;
             }
+          } catch {
+            // Ignore malformed header lines from partial/corrupt session files.
+            continue;
+          }
+        }
+        parsedSessionCache.set(sessionFile, { mtimeMs: fileStat.mtimeMs, ledger });
+        return ledger;
+      }
+
+      const lines = content.split("\n").filter(Boolean);
+
+      for (const line of lines) {
+        let entry: any;
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          // Ignore malformed JSONL lines; retention discovery is best-effort.
+          continue;
+        }
+
+        if (entry?.type === "session") {
+          ledger.sessionId = entry.id;
+          ledger.cwd = entry.cwd;
+          ledger.parentSession = entry.parentSession;
+          continue;
+        }
+
+        if (entry?.type === "custom" && entry?.customType === "rewind-turn" && isRewindTurnData(entry.data)) {
+          applyBindings(ledger.entryToCommit, entry.data.snapshots, entry.data.bindings);
+          addReferences(ledger.references, entry.data.snapshots, toTimestamp(entry.timestamp), entry.data);
+          continue;
+        }
+
+        if (entry?.type === "custom" && entry?.customType === "rewind-op" && isRewindOpData(entry.data)) {
+          applyBindings(ledger.entryToCommit, entry.data.snapshots, entry.data.bindings);
+          addReferences(ledger.references, entry.data.snapshots, toTimestamp(entry.timestamp), entry.data);
+          const currentCommitSha = getCommitFromData(entry.data, "current");
+          if (currentCommitSha) ledger.latestCurrentCommitSha = currentCommitSha;
+          const undoCommitSha = getCommitFromData(entry.data, "undo");
+          if (undoCommitSha) ledger.latestUndoCommitSha = undoCommitSha;
+          continue;
+        }
+
+        if (entry?.type === "label") {
+          updateLabelSet(ledger.labeledEntryIds, entry);
+        }
+      }
+
+      parsedSessionCache.set(sessionFile, { mtimeMs: fileStat.mtimeMs, ledger });
+      return ledger;
+    } catch {
+      // Unreadable/missing session file: skip it and continue lineage/discovery.
+      return null;
+    }
+  }
+
+  async function resolveEntrySnapshotWithLineage(entryId: string, sessionFile = currentSessionFile): Promise<string | undefined> {
+    let cursor = sessionFile;
+
+    while (cursor) {
+      const ledger = cursor === currentSessionFile ? buildCurrentSessionLedgerFromMemory() : await parseSessionLedgerFile(cursor);
+      if (!ledger) break;
+
+      const commitSha = ledger.entryToCommit.get(entryId);
+      if (commitSha && (await commitExists(commitSha))) {
+        return commitSha;
+      }
+
+      cursor = ledger.parentSession;
+    }
+
+    return undefined;
+  }
+
+  function buildCurrentSessionLedgerFromMemory(): ParsedSessionLedger {
+    return {
+      sessionFile: currentSessionFile ?? "",
+      sessionId: sessionId ?? undefined,
+      cwd: currentSessionCwd,
+      parentSession: currentParentSession,
+      entryToCommit: new Map(entryToCommit),
+      labeledEntryIds: new Set(),
+      references: [],
+      latestCurrentCommitSha: activeBranchState.currentCommitSha,
+      latestUndoCommitSha: activeBranchState.undoCommitSha,
+    };
+  }
+
+  async function reconstructState(ctx: ExtensionContext) {
+    entryToCommit.clear();
+    activeBranchState = {};
+    lastExact = null;
+
+    const currentLedger = buildCurrentSessionLedger(ctx);
+    for (const [entryId, commitSha] of currentLedger.entryToCommit.entries()) {
+      entryToCommit.set(entryId, commitSha);
+    }
+
+    let latestVisibleBindingCommitSha: string | undefined;
+    for (const entry of ctx.sessionManager.getBranch() as SessionLikeEntry[]) {
+      const boundCommitSha = entry.id ? entryToCommit.get(entry.id) : undefined;
+      if (boundCommitSha && isRestorableTreeEntry(entry)) {
+        latestVisibleBindingCommitSha = boundCommitSha;
+      }
+
+      if (entry.type === "custom" && entry.customType === "rewind-op" && isRewindOpData(entry.data)) {
+        const currentCommitSha = getCommitFromData(entry.data, "current");
+        if (currentCommitSha) {
+          activeBranchState.currentCommitSha = currentCommitSha;
+        }
+        const undoCommitSha = getCommitFromData(entry.data, "undo");
+        if (undoCommitSha) {
+          activeBranchState.undoCommitSha = undoCommitSha;
+        }
+      }
+    }
+
+    if (!activeBranchState.currentCommitSha) {
+      activeBranchState.currentCommitSha = latestVisibleBindingCommitSha;
+    }
+
+    if (activeBranchState.currentCommitSha && (await commitExists(activeBranchState.currentCommitSha))) {
+      activeBranchState.currentTreeSha = await getCommitTreeSha(activeBranchState.currentCommitSha);
+      const { treeSha: worktreeTreeSha } = await captureWorktreeTree();
+
+      if (activeBranchState.currentTreeSha === worktreeTreeSha) {
+        lastExact = {
+          commitSha: activeBranchState.currentCommitSha,
+          treeSha: activeBranchState.currentTreeSha,
+        };
+      }
+    }
+  }
+
+  async function discoverSessionFiles(scanMode: "ancestor-only" | "repo-sessions"): Promise<string[]> {
+    const discovered = new Set<string>();
+
+    if (scanMode === "repo-sessions") {
+      const roots = new Set<string>();
+      const defaultSessionsDir = getDefaultSessionsDir();
+      if (existsSync(defaultSessionsDir)) {
+        roots.add(defaultSessionsDir);
+      }
+      if (currentSessionFile) {
+        roots.add(dirname(currentSessionFile));
+      }
+
+      const stack = [...roots];
+      while (stack.length > 0) {
+        const dir = stack.pop();
+        if (!dir) continue;
+
+        let entries: Awaited<ReturnType<typeof readdir>>;
+        try {
+          entries = await readdir(dir, { withFileTypes: true });
+        } catch {
+          // Skip unreadable directories during best-effort discovery.
+          continue;
+        }
+
+        for (const entry of entries) {
+          const fullPath = join(dir, entry.name);
+          if (entry.isDirectory()) {
+            stack.push(fullPath);
+            continue;
+          }
+          if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+            discovered.add(fullPath);
           }
         }
       }
-    } catch {
-      // Silent failure - pruning is not critical
+    }
+
+    let ancestorCursor = currentSessionFile;
+    while (ancestorCursor) {
+      discovered.add(ancestorCursor);
+      const ledger = ancestorCursor === currentSessionFile ? buildCurrentSessionLedgerFromMemory() : await parseSessionLedgerFile(ancestorCursor);
+      ancestorCursor = ledger?.parentSession;
+    }
+
+    return [...discovered];
+  }
+
+  async function maybeSweepRetention(ctx: ExtensionContext, reason: "startup" | "new-snapshots" | "shutdown") {
+    const retention = getRetentionSettings();
+    if (!retention) return;
+    if (reason === "new-snapshots" && newSnapshotsSinceSweep < RETENTION_SWEEP_THRESHOLD) return;
+    if (reason === "shutdown" && sweepCompletedThisSession && newSnapshotsSinceSweep < RETENTION_SWEEP_THRESHOLD) return;
+    if (!repoRoot) return;
+    if (sweepRunning) return;
+    sweepRunning = true;
+    try {
+      await runRetentionSweep(ctx, reason);
+    } finally {
+      sweepRunning = false;
     }
   }
 
-  /**
-   * Initialize the extension for the current session/repo
-   */
+  async function runRetentionSweep(ctx: ExtensionContext, reason: "startup" | "new-snapshots" | "shutdown") {
+    const retention = getRetentionSettings();
+    if (!retention) return;
+
+    const scanMode = getRetentionScanMode();
+    const startupBudgetMs = reason === "startup" ? getStartupSweepBudgetMs() : undefined;
+    const startedAt = Date.now();
+
+    const budgetExceeded = () => typeof startupBudgetMs === "number" && Date.now() - startedAt > startupBudgetMs;
+
+    const sessionFiles = await discoverSessionFiles(scanMode);
+    if (budgetExceeded()) {
+      notify(ctx, `Rewind retention startup sweep skipped after exceeding ${startupBudgetMs}ms budget`, "warning");
+      return;
+    }
+
+    const ledgers: ParsedSessionLedger[] = [];
+
+    for (const sessionFile of sessionFiles) {
+      if (budgetExceeded()) {
+        notify(ctx, `Rewind retention startup sweep skipped after exceeding ${startupBudgetMs}ms budget`, "warning");
+        return;
+      }
+
+      const ledger = sessionFile === currentSessionFile ? buildCurrentSessionLedger(ctx) : await parseSessionLedgerFile(sessionFile);
+      if (!ledger?.cwd) continue;
+      if (!isInsidePath(ledger.cwd, repoRoot)) continue;
+      ledgers.push(ledger);
+    }
+
+    const latestReferenceByCommit = new Map<string, number>();
+    const pinnedCommits = new Set<string>();
+    const currentCommits = new Set<string>();
+    const undoCommits = new Set<string>();
+
+    for (const ledger of ledgers) {
+      if (budgetExceeded()) {
+        notify(ctx, `Rewind retention startup sweep skipped after exceeding ${startupBudgetMs}ms budget`, "warning");
+        return;
+      }
+
+      for (const reference of ledger.references) {
+        const prev = latestReferenceByCommit.get(reference.commitSha) ?? 0;
+        if (reference.timestamp > prev) {
+          latestReferenceByCommit.set(reference.commitSha, reference.timestamp);
+        }
+        if (reference.kind === "binding" && retention.pinLabeledEntries && reference.entryId && ledger.labeledEntryIds.has(reference.entryId)) {
+          pinnedCommits.add(reference.commitSha);
+        }
+      }
+
+      if (ledger.latestCurrentCommitSha) {
+        currentCommits.add(ledger.latestCurrentCommitSha);
+      }
+      if (ledger.latestUndoCommitSha) {
+        undoCommits.add(ledger.latestUndoCommitSha);
+      }
+    }
+
+    for (const commitSha of [...currentCommits, ...undoCommits]) {
+      if (budgetExceeded()) {
+        notify(ctx, `Rewind retention startup sweep skipped after exceeding ${startupBudgetMs}ms budget`, "warning");
+        return;
+      }
+      if (await commitExists(commitSha)) {
+        pinnedCommits.add(commitSha);
+      }
+    }
+
+    let candidates = [...latestReferenceByCommit.entries()]
+      .filter(([commitSha]) => !pinnedCommits.has(commitSha))
+      .sort((left, right) => right[1] - left[1]);
+
+    if (typeof retention.maxAgeDays === "number" && retention.maxAgeDays >= 0) {
+      const cutoff = Date.now() - retention.maxAgeDays * 24 * 60 * 60 * 1000;
+      candidates = candidates.filter(([, timestamp]) => timestamp >= cutoff);
+    }
+
+    if (typeof retention.maxSnapshots === "number" && retention.maxSnapshots >= 0 && candidates.length > retention.maxSnapshots) {
+      candidates = candidates.slice(0, retention.maxSnapshots);
+    }
+
+    const liveSet = [...new Set([...pinnedCommits, ...candidates.map(([commitSha]) => commitSha)])];
+    const existingLiveSet: string[] = [];
+    for (const commitSha of liveSet) {
+      if (budgetExceeded()) {
+        notify(ctx, `Rewind retention startup sweep skipped after exceeding ${startupBudgetMs}ms budget`, "warning");
+        return;
+      }
+      if (await commitExists(commitSha)) {
+        existingLiveSet.push(commitSha);
+      }
+    }
+
+    const rewriteResult = await rewriteStoreToLiveSet(existingLiveSet);
+    if (rewriteResult === "preserved-empty") {
+      return;
+    }
+
+    // Skip gc on background startup sweeps to avoid racing with concurrent snapshot creation
+    if (reason !== "startup") {
+      try {
+        const result = await pi.exec("git", ["gc", "--auto"]);
+        if (result.code !== 0) {
+          throw new Error(result.stderr.trim() || `git gc --auto failed with code ${result.code}`);
+        }
+      } catch {
+        // Best effort only; retention reachability rewrite already completed.
+      }
+    }
+
+    newSnapshotsSinceSweep = 0;
+    sweepCompletedThisSession = true;
+    updateStatus(ctx);
+  }
+
   async function initializeForSession(ctx: ExtensionContext) {
-    if (!ctx.hasUI) return;
-
-    // Reset all state for fresh initialization
     resetState();
-
-    // Capture session ID for scoping checkpoints
-    sessionId = ctx.sessionManager.getSessionId();
+    syncSessionIdentity(ctx);
 
     try {
       const result = await pi.exec("git", ["rev-parse", "--is-inside-work-tree"]);
-      isGitRepo = result.stdout.trim() === "true";
+      isGitRepo = result.code === 0 && result.stdout.trim() === "true";
     } catch {
+      // Treat git probing failures as non-git context for this session.
       isGitRepo = false;
     }
 
     if (!isGitRepo) {
-      ctx.ui.setStatus(STATUS_KEY, undefined);
+      updateStatus(ctx);
       return;
     }
 
-    // Rebuild checkpoints map from existing git refs (for resumed sessions)
-    // Only loads checkpoints belonging to this session
-    await rebuildCheckpointsMap(pi.exec, sessionId);
-
-    // Create a resume checkpoint for the current state (session-scoped like other checkpoints)
-    const checkpointId = `checkpoint-resume-${sessionId}-${Date.now()}`;
-
-    try {
-      const success = await createCheckpointFromWorktree(pi.exec, checkpointId);
-      if (success) {
-        resumeCheckpoint = checkpointId;
-      }
-    } catch {
-      // Silent failure - resume checkpoint is optional
-    }
-    
+    await getRepoRoot(pi.exec);
+    await reconstructState(ctx);
     updateStatus(ctx);
+    maybeSweepRetention(ctx, "startup").catch((error) => {
+      notify(ctx, `Rewind retention startup sweep failed: ${error instanceof Error ? error.message : String(error)}`, "warning");
+    });
   }
+
+  pi.events.on("rewind:fork-preference", (data: any) => {
+    if (data?.mode !== "conversation-only") return;
+    if (typeof data?.source !== "string") return;
+    if (!FORK_PREFERENCE_SOURCE_ALLOWLIST.has(data.source)) return;
+    forceConversationOnlyOnNextFork = true;
+    forceConversationOnlySource = data.source;
+  });
+
+  pi.on("before_agent_start", async (event) => {
+    activePromptText = event.prompt;
+  });
 
   pi.on("session_start", async (_event, ctx) => {
     await initializeForSession(ctx);
   });
-  
+
   pi.on("session_switch", async (_event, ctx) => {
     await initializeForSession(ctx);
   });
 
-  pi.on("turn_start", async (event, ctx) => {
-    if (!ctx.hasUI) return;
+  pi.on("session_fork", async (_event, ctx) => {
+    syncSessionIdentity(ctx);
+    if (!isGitRepo || !pendingForkState) {
+      await reconstructState(ctx);
+      updateStatus(ctx);
+      return;
+    }
+
+    const snapshots = [pendingForkState.currentCommitSha];
+    const data: RewindOpData = { v: RETENTION_VERSION, snapshots, current: 0 };
+    if (pendingForkState.undoCommitSha) {
+      data.snapshots.push(pendingForkState.undoCommitSha);
+      data.undo = 1;
+    }
+
+    appendRewindOp(ctx, data);
+    pendingForkState = null;
+    await reconstructState(ctx);
+    updateStatus(ctx);
+  });
+
+  pi.on("session_tree", async (event, ctx) => {
+    syncSessionIdentity(ctx);
+    if (!isGitRepo || !pendingTreeState) {
+      await reconstructState(ctx);
+      updateStatus(ctx);
+      return;
+    }
+
+    const snapshots = [pendingTreeState.currentCommitSha];
+    const data: RewindOpData = { v: RETENTION_VERSION, snapshots, current: 0 };
+    if (pendingTreeState.undoCommitSha) {
+      data.snapshots.push(pendingTreeState.undoCommitSha);
+      data.undo = 1;
+    }
+    if (event.summaryEntry?.id) {
+      data.bindings = [[event.summaryEntry.id, 0]];
+    }
+
+    appendRewindOp(ctx, data);
+    pendingTreeState = null;
+    await reconstructState(ctx);
+    updateStatus(ctx);
+  });
+
+  pi.on("session_compact", async (event, ctx) => {
+    syncSessionIdentity(ctx);
     if (!isGitRepo) return;
-    
-    // Only capture at the start of a new agent loop (first turn).
-    // This is when a user message triggers the agent - we want to snapshot
-    // the file state BEFORE any tools execute.
+
+    let currentCommitSha = activeBranchState.currentCommitSha;
+    if (!currentCommitSha) {
+      currentCommitSha = await ensureSnapshotForCurrentWorktree();
+    }
+
+    appendRewindOp(ctx, {
+      v: RETENTION_VERSION,
+      snapshots: [currentCommitSha],
+      bindings: [[event.compactionEntry.id, 0]],
+    });
+    await reconstructState(ctx);
+    updateStatus(ctx);
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    syncSessionIdentity(ctx);
+    if (!isGitRepo) return;
+    await maybeSweepRetention(ctx, "shutdown");
+  });
+
+  pi.on("turn_start", async (event, ctx) => {
+    if (!isGitRepo) return;
     if (event.turnIndex !== 0) return;
 
     try {
-      // Capture worktree state now, but don't create the ref yet.
-      // At this point, the user message hasn't been appended to the session,
-      // so we don't know its entry ID. We'll create the ref at turn_end.
-      const commitSha = await captureWorktree();
-      pendingCheckpoint = { commitSha, timestamp: event.timestamp };
-    } catch {
-      pendingCheckpoint = null;
+      const { treeSha } = await captureWorktreeTree();
+      const commitSha = await ensureSnapshotForTree(treeSha);
+      promptCollector = {
+        snapshots: [],
+        bindings: [],
+        promptText: activePromptText ?? undefined,
+        pendingUserCommitSha: commitSha,
+      };
+
+      bindPendingPromptUser(ctx.sessionManager.getBranch() as SessionLikeEntry[], promptCollector);
+    } catch (error) {
+      promptCollector = null;
+      notify(ctx, `Rewind: failed to capture start snapshot (${error instanceof Error ? error.message : String(error)})`, "warning");
     }
   });
 
   pi.on("turn_end", async (event, ctx) => {
-    if (!ctx.hasUI) return;
-    if (!isGitRepo) return;
-    if (!pendingCheckpoint) return;
-    if (!sessionId) return;
-    
-    // Only process at end of first turn - by now the user message has been
-    // appended to the session and we can find its entry ID.
-    if (event.turnIndex !== 0) return;
+    if (!isGitRepo || !promptCollector) return;
 
     try {
-      const userEntry = findUserMessageEntry(ctx.sessionManager);
-      if (!userEntry) return;
+      const branchEntries = ctx.sessionManager.getBranch() as SessionLikeEntry[];
+      bindPendingPromptUser(branchEntries, promptCollector);
 
-      const entryId = userEntry.id;
-      const sanitizedEntryId = sanitizeForRef(entryId);
-      // Include session ID in checkpoint name to scope it per-session
-      const checkpointId = `checkpoint-${sessionId}-${pendingCheckpoint.timestamp}-${sanitizedEntryId}`;
+      if (event.message.role !== "assistant") return;
 
-      // Create the git ref for this checkpoint
-      await pi.exec("git", [
-        "update-ref",
-        `${REF_PREFIX}${checkpointId}`,
-        pendingCheckpoint.commitSha,
-      ]);
+      const assistantEntry = findAssistantEntryForTurn(branchEntries, event.message);
+      if (!assistantEntry) return;
 
-      checkpoints.set(sanitizedEntryId, checkpointId);
-      await pruneCheckpoints(pi.exec, sessionId);
+      const { treeSha } = await captureWorktreeTree();
+      const commitSha = await ensureSnapshotForTree(treeSha);
+      addBindingToCollector(promptCollector, assistantEntry.id, commitSha);
+    } catch (error) {
+      notify(ctx, `Rewind: failed to capture assistant snapshot (${error instanceof Error ? error.message : String(error)})`, "warning");
+    }
+  });
+
+  pi.on("agent_end", async (_event, ctx) => {
+    if (!isGitRepo || !promptCollector) return;
+
+    try {
+      bindPendingPromptUser(ctx.sessionManager.getBranch() as SessionLikeEntry[], promptCollector);
+      appendRewindTurn(ctx, promptCollector);
+      await reconstructState(ctx);
       updateStatus(ctx);
-      if (!getSilentCheckpointsSetting()) {
-        ctx.ui.notify(`Checkpoint ${checkpoints.size} saved`, "info");
-      }
-    } catch {
-      // Silent failure - checkpoint creation is not critical
+      await maybeSweepRetention(ctx, "new-snapshots");
+    } catch (error) {
+      notify(ctx, `Rewind: failed to finalize rewind turn (${error instanceof Error ? error.message : String(error)})`, "warning");
     } finally {
-      pendingCheckpoint = null;
+      promptCollector = null;
+      activePromptText = null;
     }
   });
 
   pi.on("session_before_fork", async (event, ctx) => {
-    if (!ctx.hasUI) return;
-    if (!sessionId) return;
+    const shouldForceConversationOnly = forceConversationOnlyOnNextFork;
+    const forcedBySource = forceConversationOnlySource;
+    forceConversationOnlyOnNextFork = false;
+    forceConversationOnlySource = null;
+
+    if (!isGitRepo) return;
 
     try {
-      const result = await pi.exec("git", ["rev-parse", "--is-inside-work-tree"]);
-      if (result.stdout.trim() !== "true") return;
-    } catch {
-      return;
-    }
-
-    const sanitizedEntryId = sanitizeForRef(event.entryId);
-    let checkpointId = checkpoints.get(sanitizedEntryId);
-    let usingResumeCheckpoint = false;
-
-    if (!checkpointId && resumeCheckpoint) {
-      checkpointId = resumeCheckpoint;
-      usingResumeCheckpoint = true;
-    }
-
-    const beforeRestoreRef = await findBeforeRestoreRef(pi.exec, sessionId);
-    const hasUndo = !!beforeRestoreRef;
-
-    const options: string[] = [];
-
-    // Conversation-only (non-file-restorative) first as most common action
-    options.push("Conversation only (keep current files)");
-    
-    if (checkpointId) {
-      if (usingResumeCheckpoint) {
-        options.push("Restore to session start (files + conversation)");
-        options.push("Restore to session start (files only, keep conversation)");
-      } else {
-        options.push("Restore all (files + conversation)");
-        options.push("Code only (restore files, keep conversation)");
+      if (!ctx.hasUI) {
+        pendingForkState = { currentCommitSha: await ensureSnapshotForCurrentWorktree() };
+        return;
       }
-    }
 
-    if (hasUndo) {
-      options.push("Undo last file rewind");
-    }
+      const targetCommitSha = await resolveEntrySnapshotWithLineage(event.entryId);
+      const hasUndo = Boolean(activeBranchState.undoCommitSha && (await commitExists(activeBranchState.undoCommitSha)));
 
-    const choice = await ctx.ui.select("Restore Options", options);
-
-    if (!choice) {
-      ctx.ui.notify("Rewind cancelled", "info");
-      return { cancel: true };
-    }
-
-    if (choice.startsWith("Conversation only")) {
-      return;
-    }
-
-    const isCodeOnly = choice === "Code only (restore files, keep conversation)" ||
-      choice === "Restore to session start (files only, keep conversation)";
-
-    if (choice === "Undo last file rewind") {
-      const success = await restoreWithBackup(
-        pi.exec,
-        beforeRestoreRef!.commitSha,
-        sessionId,
-        ctx.ui.notify.bind(ctx.ui)
-      );
-      if (success) {
-        ctx.ui.notify("Files restored to before last rewind", "info");
+      if (shouldForceConversationOnly) {
+        pendingForkState = { currentCommitSha: await ensureSnapshotForCurrentWorktree() };
+        notify(ctx, `Rewind: using conversation-only fork (keep current files)${forcedBySource ? ` (${forcedBySource})` : ""}`);
+        return;
       }
-      return { cancel: true };
-    }
 
-    if (!checkpointId) {
-      ctx.ui.notify("No checkpoint available", "error");
-      return { cancel: true };
-    }
+      const options = ["Conversation only (keep current files)"];
+      if (targetCommitSha) {
+        options.push("Restore all (files + conversation)", "Code only (restore files, keep conversation)");
+      }
+      if (hasUndo) {
+        options.push("Undo last file rewind");
+      }
 
-    const ref = `${REF_PREFIX}${checkpointId}`;
-    const success = await restoreWithBackup(
-      pi.exec,
-      ref,
-      sessionId,
-      ctx.ui.notify.bind(ctx.ui)
-    );
-    
-    if (!success) {
-      // File restore failed - cancel the branch operation entirely
-      // (restoreWithBackup already notified the user of the error)
-      return { cancel: true };
-    }
-    
-    ctx.ui.notify(
-      usingResumeCheckpoint
-        ? "Files restored to session start"
-        : "Files restored from checkpoint",
-      "info"
-    );
+      const choice = await ctx.ui.select("Restore Options", options);
+      if (!choice) {
+        notify(ctx, "Rewind cancelled");
+        return { cancel: true };
+      }
 
-    if (isCodeOnly) {
-      return { skipConversationRestore: true };
+      if (choice === "Undo last file rewind") {
+        const restore = await restoreCommitExactly(activeBranchState.undoCommitSha!);
+        pendingForkState = {
+          currentCommitSha: activeBranchState.undoCommitSha!,
+          undoCommitSha: restore.undoCommitSha,
+        };
+        notify(ctx, "Files restored to before last rewind");
+        return;
+      }
+
+      if (choice === "Conversation only (keep current files)") {
+        pendingForkState = { currentCommitSha: await ensureSnapshotForCurrentWorktree() };
+        return;
+      }
+
+      if (!targetCommitSha) {
+        notify(ctx, "No exact rewind point available for that entry", "error");
+        return { cancel: true };
+      }
+
+      const restore = await restoreCommitExactly(targetCommitSha);
+      pendingForkState = {
+        currentCommitSha: targetCommitSha,
+        undoCommitSha: restore.undoCommitSha,
+      };
+      notify(ctx, "Files restored from rewind point");
+
+      if (choice === "Code only (restore files, keep conversation)") {
+        return { skipConversationRestore: true };
+      }
+    } catch (error) {
+      pendingForkState = null;
+      notify(ctx, `Rewind failed before fork: ${error instanceof Error ? error.message : String(error)}`, "error");
+      return { cancel: true };
     }
   });
 
   pi.on("session_before_tree", async (event, ctx) => {
-    if (!ctx.hasUI) return;
-    if (!sessionId) return;
+    if (!isGitRepo || !ctx.hasUI) return;
 
     try {
-      const result = await pi.exec("git", ["rev-parse", "--is-inside-work-tree"]);
-      if (result.stdout.trim() !== "true") return;
-    } catch {
-      return;
-    }
+      const targetEntry = ctx.sessionManager.getEntry(event.preparation.targetId) as SessionLikeEntry | undefined;
+      const targetCommitSha = isRestorableTreeEntry(targetEntry)
+        ? await resolveEntrySnapshotWithLineage(event.preparation.targetId, currentSessionFile)
+        : undefined;
+      const hasUndo = Boolean(activeBranchState.undoCommitSha && (await commitExists(activeBranchState.undoCommitSha)));
 
-    const targetId = event.preparation.targetId;
-    const sanitizedTargetId = sanitizeForRef(targetId);
-    let checkpointId = checkpoints.get(sanitizedTargetId);
-    let usingResumeCheckpoint = false;
-
-    if (!checkpointId && resumeCheckpoint) {
-      checkpointId = resumeCheckpoint;
-      usingResumeCheckpoint = true;
-    }
-
-    const beforeRestoreRef = await findBeforeRestoreRef(pi.exec, sessionId);
-    const hasUndo = !!beforeRestoreRef;
-
-    const options: string[] = [];
-
-    // Keep current files first as most common action (non-file-restorative navigation)
-    options.push("Keep current files");
-
-    if (checkpointId) {
-      if (usingResumeCheckpoint) {
-        options.push("Restore files to session start");
-      } else {
+      const options = ["Keep current files"];
+      if (targetCommitSha) {
         options.push("Restore files to that point");
       }
-    }
-
-    if (hasUndo) {
-      options.push("Undo last file rewind");
-    }
-
-    options.push("Cancel navigation");
-
-    const choice = await ctx.ui.select("Restore Options", options);
-
-    if (!choice || choice === "Cancel navigation") {
-      ctx.ui.notify("Navigation cancelled", "info");
-      return { cancel: true };
-    }
-
-    if (choice === "Keep current files") {
-      return;
-    }
-
-    if (choice === "Undo last file rewind") {
-      const success = await restoreWithBackup(
-        pi.exec,
-        beforeRestoreRef!.commitSha,
-        sessionId,
-        ctx.ui.notify.bind(ctx.ui)
-      );
-      if (success) {
-        ctx.ui.notify("Files restored to before last rewind", "info");
+      if (hasUndo) {
+        options.push("Undo last file rewind");
       }
-      return { cancel: true };
-    }
+      options.push("Cancel navigation");
 
-    if (!checkpointId) {
-      ctx.ui.notify("No checkpoint available", "error");
-      return { cancel: true };
-    }
+      const choice = await ctx.ui.select("Restore Options", options);
+      if (!choice || choice === "Cancel navigation") {
+        notify(ctx, "Navigation cancelled");
+        return { cancel: true };
+      }
 
-    const ref = `${REF_PREFIX}${checkpointId}`;
-    const success = await restoreWithBackup(
-      pi.exec,
-      ref,
-      sessionId,
-      ctx.ui.notify.bind(ctx.ui)
-    );
-    
-    if (!success) {
-      // File restore failed - cancel navigation
-      // (restoreWithBackup already notified the user of the error)
+      if (choice === "Undo last file rewind") {
+        const restore = await restoreCommitExactly(activeBranchState.undoCommitSha!);
+        const snapshots = [activeBranchState.undoCommitSha!];
+        const data: RewindOpData = { v: RETENTION_VERSION, snapshots, current: 0 };
+        if (restore.undoCommitSha) {
+          data.snapshots.push(restore.undoCommitSha);
+          data.undo = 1;
+        }
+        appendRewindOp(ctx, data);
+        notify(ctx, "Files restored to before last rewind");
+        await reconstructState(ctx);
+        return { cancel: true };
+      }
+
+      if (choice === "Keep current files") {
+        pendingTreeState = { currentCommitSha: await ensureSnapshotForCurrentWorktree() };
+        return;
+      }
+
+      if (!targetCommitSha) {
+        notify(ctx, "Exact file rewind is only available for user, assistant, compaction, and summary nodes", "error");
+        return { cancel: true };
+      }
+
+      const restore = await restoreCommitExactly(targetCommitSha);
+      pendingTreeState = {
+        currentCommitSha: targetCommitSha,
+        undoCommitSha: restore.undoCommitSha,
+      };
+      notify(ctx, "Files restored to rewind point");
+    } catch (error) {
+      pendingTreeState = null;
+      notify(ctx, `Rewind failed before tree navigation: ${error instanceof Error ? error.message : String(error)}`, "error");
       return { cancel: true };
     }
-    
-    ctx.ui.notify(
-      usingResumeCheckpoint
-        ? "Files restored to session start"
-        : "Files restored to checkpoint",
-      "info"
-    );
   });
-
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-rewind-hook",
-  "version": "1.7.3",
+  "version": "1.7.0",
   "description": "Rewind extension for Pi agent - automatic git checkpoints with file/conversation restore",
   "bin": {
     "pi-rewind-hook": "./install.js"
@@ -10,7 +10,6 @@
     "url": "https://github.com/nicobailon/pi-rewind-hook"
   },
   "keywords": [
-    "pi-package",
     "pi",
     "pi-agent",
     "extension",
@@ -21,8 +20,12 @@
   "author": "nicobailon",
   "license": "MIT",
   "pi": {
-    "extensions": [
-      "./index.ts"
-    ]
+    "extensions": ["./index.ts"]
+  },
+  "scripts": {
+    "test": "npx --yes tsx --tsconfig tsconfig.test.json --test index.test.ts"
+  },
+  "devDependencies": {
+    "@mariozechner/pi-coding-agent": "^0.51.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-rewind-hook",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "Rewind extension for Pi agent - automatic git checkpoints with file/conversation restore",
   "bin": {
     "pi-rewind-hook": "./install.js"
@@ -10,6 +10,7 @@
     "url": "https://github.com/nicobailon/pi-rewind-hook"
   },
   "keywords": [
+    "pi-package",
     "pi",
     "pi-agent",
     "extension",

--- a/test-support/pi-coding-agent-shim.ts
+++ b/test-support/pi-coding-agent-shim.ts
@@ -1,0 +1,6 @@
+export function getAgentDir(): string {
+  return process.env.PI_CODING_AGENT_DIR ?? "";
+}
+
+export type ExtensionAPI = any;
+export type ExtensionContext = any;

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@mariozechner/pi-coding-agent": ["./test-support/pi-coding-agent-shim.ts"]
+    }
+  }
+}


### PR DESCRIPTION
This ports the session-native rewind storage rewrite and hardens it for production usage.

It replaces per-checkpoint refs with a session-ledger model (`rewind-turn` / `rewind-op`) and a single keepalive store ref, adds lineage-aware snapshot lookup across parent sessions, and introduces retention controls plus graceful error handling in critical rewind flows.

Attribution:
- Adapted from `w-winter/dot314` commit `b43267682059a4b7c37d557b608e8413ecbd0298`
- Source changelog notes: https://github.com/w-winter/dot314/blob/main/extensions/rewind/CHANGELOG.md#unreleased
- Co-authored-by trailer included in commit metadata

Validation:
- `npm test --silent` (8 passing)
