### PR TITLE
feat: fallback to ~/.pi/agent/rewind-data/ when not in a git repo

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -422,6 +422,7 @@ export default function rewindExtension(pi: ExtensionAPI) {
     currentParentSession = undefined;
     currentSessionCwd = undefined;
     isGitRepo = false;
+    usingFallbackRepo = false;
     lastExact = null;
     activeBranchState = {};
     promptCollector = null;
@@ -999,7 +1000,7 @@ export default function rewindExtension(pi: ExtensionAPI) {
 
       const ledger = sessionFile === currentSessionFile ? buildCurrentSessionLedger(ctx) : await parseSessionLedgerFile(sessionFile);
       if (!ledger?.cwd) continue;
-      if (!isInsidePath(ledger.cwd, repoRoot)) continue;
+      if (!usingFallbackRepo && !isInsidePath(ledger.cwd, repoRoot)) continue;
       ledgers.push(ledger);
     }
 
@@ -1107,6 +1108,7 @@ export default function rewindExtension(pi: ExtensionAPI) {
     await reconstructState(ctx);
     updateStatus(ctx);
   }
+  let usingFallbackRepo = false;
 
   async function initializeForSession(ctx: ExtensionContext) {
     activeContext = ctx;
@@ -1117,8 +1119,23 @@ export default function rewindExtension(pi: ExtensionAPI) {
       const result = await pi.exec("git", ["rev-parse", "--is-inside-work-tree"]);
       isGitRepo = result.code === 0 && result.stdout.trim() === "true";
     } catch {
-      // Treat git probing failures as non-git context for this session.
       isGitRepo = false;
+    }
+
+    if (!isGitRepo) {
+      // Fallback: use ~/.pi/agent/rewind-data/ as a dedicated git repo
+      const rewindDir = process.env.HOME + "/.pi/agent/rewind-data";
+      try {
+        const result = await pi.exec("git", ["-C", rewindDir, "rev-parse", "--is-inside-work-tree"]);
+        isGitRepo = result.code === 0 && result.stdout.trim() === "true";
+        if (isGitRepo) {
+          process.env.GIT_DIR = rewindDir + "/.git";
+          process.env.GIT_WORK_TREE = rewindDir;
+          usingFallbackRepo = true;
+        }
+      } catch {
+        isGitRepo = false;
+      }
     }
 
     if (!isGitRepo) {
@@ -1133,6 +1150,7 @@ export default function rewindExtension(pi: ExtensionAPI) {
       notify(ctx, `Rewind retention startup sweep failed: ${error instanceof Error ? error.message : String(error)}`, "warning");
     });
   }
+
 
   pi.events.on("rewind:fork-preference", (data) => {
     if (!data || typeof data !== "object") return;

--- a/index.ts
+++ b/index.ts
@@ -767,8 +767,6 @@ export default function rewindExtension(pi: ExtensionAPI) {
               break;
             }
           } catch {
-            // Ignore malformed header lines from partial/corrupt session files.
-            continue;
           }
         }
         parsedSessionCache.set(sessionFile, { mtimeMs: fileStat.mtimeMs, ledger });
@@ -1123,18 +1121,31 @@ export default function rewindExtension(pi: ExtensionAPI) {
     }
 
     if (!isGitRepo) {
-      // Fallback: use ~/.pi/agent/rewind-data/ as a dedicated git repo
+      // Fallback: auto-create and use ~/.pi/agent/rewind-data/ as a dedicated git repo
       const rewindDir = process.env.HOME + "/.pi/agent/rewind-data";
       try {
+        // Check if it's already a git repo
         const result = await pi.exec("git", ["-C", rewindDir, "rev-parse", "--is-inside-work-tree"]);
         isGitRepo = result.code === 0 && result.stdout.trim() === "true";
-        if (isGitRepo) {
-          process.env.GIT_DIR = rewindDir + "/.git";
-          process.env.GIT_WORK_TREE = rewindDir;
-          usingFallbackRepo = true;
-        }
       } catch {
-        isGitRepo = false;
+        // Doesn't exist or not a git repo — create it
+        try {
+          await pi.exec("mkdir", ["-p", rewindDir]);
+          await pi.exec("git", ["init", rewindDir]);
+          await pi.exec("git", ["-C", rewindDir, "config", "user.email", "rewind@pi.dev"]);
+          await pi.exec("git", ["-C", rewindDir, "config", "user.name", "pi-rewind"]);
+          await pi.exec("sh", ["-c", "echo -n > " + rewindDir + "/.session"]);
+          await pi.exec("git", ["-C", rewindDir, "add", "-A"]);
+          await pi.exec("git", ["-C", rewindDir, "commit", "-m", "init"]);
+          isGitRepo = true;
+        } catch {
+          isGitRepo = false;
+        }
+      }
+      if (isGitRepo) {
+        process.env.GIT_DIR = rewindDir + "/.git";
+        process.env.GIT_WORK_TREE = rewindDir;
+        usingFallbackRepo = true;
       }
     }
 


### PR DESCRIPTION
## Summary

When the user runs pi from a directory that is not inside a git repository (e.g., their home directory), the rewind hook currently silently disables itself. This patch adds a fallback to an auto-created dedicated git repo at `~/.pi/agent/rewind-data/`.

## Changes

1. **`initializeForSession`** — If `git rev-parse --is-inside-work-tree` fails in CWD, auto-creates `~/.pi/agent/rewind-data/` with an initial git commit and uses it as the fallback repo. Sets `GIT_DIR` and `GIT_WORK_TREE` env vars and tracks `usingFallbackRepo` flag.

2. **`resetState()`** — Resets `usingFallbackRepo` flag on state re-initialization.

3. **Retention sweep** — Skips the `isInsidePath(ledger.cwd, repoRoot)` filter when using the fallback repo, since session CWDs won't be inside the fallback repo.

No manual setup required — the fallback repo is created on first use.